### PR TITLE
Creating a hybrid property with more efficient getter and setter

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -30,7 +30,30 @@ def Message(Base):
 
 
 @pytest.fixture(scope="session")
-def engine(Base, Message):
+def Booking(Base):
+    class Booking(Base):
+        __tablename__ = "booking"
+        __mapper_args__ = {"polymorphic_on": "type", "polymorphic_identity": "standard"}
+        id = sa.Column(sa.Integer, primary_key=True)
+        type = sa.Column(sa.Text)
+        paid_at = sa.Column(sa.DateTime)
+        is_paid = column_flag(paid_at)
+
+    return Booking
+
+
+@pytest.fixture(scope="session")
+def Cancellable(Booking):
+    class CancellableBooking(Booking):
+        __mapper_args__ = {"polymorphic_identity": "cancellable"}
+        cancelled_at = sa.Column(sa.DateTime)
+        is_cancelled = column_flag(cancelled_at)
+
+    return CancellableBooking
+
+
+@pytest.fixture(scope="session")
+def engine(Base, Message, Booking, Cancellable):
     """Sets up an SQLite databae engine and configures required tables."""
     engine = sa.create_engine("sqlite://", echo=True)
     Base.metadata.create_all(bind=engine)

--- a/sqlalchemy_column_flag.py
+++ b/sqlalchemy_column_flag.py
@@ -21,15 +21,17 @@ class DerivedColumn:
 
         When multiple mappers exist for the same table, this may lead to an
         unresolvable conflict, but only if the column's attribute name differs
-        between mappers. In the case of single table inheritance there is a
-        single table with multiple mappers, but the attribute names are shared,
-        avoiding conflict.
+        between mappers.
+
+        In the case of single table inheritance, the column property might be
+        absent on some mappers, but has the same name on those that contain it.
         """
         target_names = set()
         for mapper in mapperlib._mapper_registry:
             if self.column.table in mapper.tables:
-                attr = mapper.get_property_by_column(self.column)
-                target_names.add(attr.key)
+                if self.column in mapper.columns.values():
+                    attr = mapper.get_property_by_column(self.column)
+                    target_names.add(attr.key)
         if len(target_names) != 1:
             raise TypeError("Unable to find unambiguous column attribute name.")
         self.target = next(iter(target_names))

--- a/sqlalchemy_column_flag.py
+++ b/sqlalchemy_column_flag.py
@@ -2,23 +2,53 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.inspection import inspect
 
 
+class DerivedColumn:
+    def __init__(self, column, default=None):
+        self.column = column
+        self.default = default
+
+    def _default_functions(self):
+        setter = self.default
+        if not callable(setter):
+            setter = lambda: self.default  # noqa
+        return {True: setter, False: lambda: None}
+
+    def make_getter(self):
+        def _fget(self, column=self.column):
+            mapper = inspect(self).mapper
+            target = mapper.get_property_by_column(column).key
+            return getattr(self, target) is not None
+
+        return _fget
+
+    def make_setter(self):
+        if self.default is None:
+            return None
+        defaults = self._default_functions()
+
+        def _fset(self, value, column=self.column, defaults=defaults):
+            if not isinstance(value, bool):
+                raise TypeError("Flag only accepts boolean values")
+            mapper = inspect(self).mapper
+            target = mapper.get_property_by_column(column).key
+            return setattr(self, target, defaults[value]())
+
+        return _fset
+
+    def make_expression(self):
+        def _expr(cls, expr=self.column.isnot(None)):
+            return expr
+
+        return _expr
+
+    def create_hybrid(self):
+        return hybrid_property(
+            fget=self.make_getter(),
+            fset=self.make_setter(),
+            expr=self.make_expression(),
+        )
+
+
 def column_flag(column, **options):
-    def target_key(instance):
-        target = inspect(instance).mapper.get_property_by_column(column)
-        return target.key
-
-    def fget(self):
-        return getattr(self, target_key(self)) is not None
-
-    def fset(self, value, default=options.get("default")):
-        if not isinstance(value, bool):
-            raise TypeError("Flag only accepts boolean values")
-        if callable(default):
-            default = default()
-        return setattr(self, target_key(self), default if value else None)
-
-    def expr(cls):
-        return column.isnot(None)
-
-    return hybrid_property(
-        fget=fget, fset=fset if "default" in options else None, expr=expr)
+    derived = DerivedColumn(column, **options)
+    return derived.create_hybrid()

--- a/test_column_flag.py
+++ b/test_column_flag.py
@@ -124,3 +124,20 @@ def test_assign_non_bool_error(Message, flag_value):
 
     with pytest.raises(TypeError, match="boolean"):
         Message(is_sent=flag_value)
+
+
+def test_table_inheritance_base(Booking):
+    booking = Booking(paid_at=datetime.utcnow())
+    assert booking.type == "standard"
+    assert booking.is_paid
+    assert not hasattr(booking, 'cancelled_at')
+    assert not hasattr(booking, 'is_cancelled')
+
+
+def test_table_inheritance_subclass(Cancellable):
+    booking = Cancellable(paid_at=datetime.utcnow())
+    assert booking.type == "cancellable"
+    assert booking.is_paid
+    assert not booking.is_cancelled
+    booking.cancelled_at = datetime.utcnow()
+    assert booking.is_cancelled


### PR DESCRIPTION
This implements a lookup of the ORM attribute for the targeted column, attached to an ORM event for when the mapper of the relevant class is created. This allows for both the getter and setter to resolve a static attribute name rather than having to go through the runtime inspection of SQLAlchemy, which brings the execution time down to basic `hybrid_property` speeds (~2x faster then before, ~15% slower than hybrid).

It also adds tests for the case of single-table inheritance, which ought to be the most likely case for unambiguous attribute resolution.