### PR TITLE
Multi column expressions

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -25,6 +25,7 @@ def Message(Base):
         is_sent = column_flag(sent_at, default=sa.func.now())
         is_sent_scalar = column_flag(sent_at, default=datetime(2020, 1, 1))
         is_delivered = column_flag(delivered_at, default=datetime.utcnow)
+        in_transit = column_flag(sent_at & ~delivered_at)
 
     return Message
 

--- a/expression.py
+++ b/expression.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import operator
+from collections import deque
+from enum import Enum, auto
+from typing import Any, Dict, Iterator
+
+from sqlalchemy.sql import operators
+from sqlalchemy.sql.elements import (
+    AsBoolean,
+    BinaryExpression,
+    BindParameter,
+    BooleanClauseList,
+    ColumnElement,
+    Grouping,
+    Null,
+    UnaryExpression,
+)
+from sqlalchemy.sql.schema import Column
+from sqlalchemy.sql.sqltypes import Boolean
+
+OPERATOR_MAP = {
+    operators.is_: operator.eq,
+    operators.isnot: operator.ne,
+    operators.istrue: None,
+    operators.isfalse: operator.not_,
+}
+
+
+class Expression:
+    """Provides runtime Python evaluation of SQLAlchemy expressions.
+
+    A given SQLAlchemy expression is converted into an internal serialized
+    format that allows runtime Python execution based on substitute values for
+    the columns involved in the expression. The method to use for this is
+    `.evaluate()`.
+
+    When `forrce_bool` is True, bare columns and inverted columns (~Column) are
+    converted to booleans. In this operating mode, a column value is False when
+    it is None (equivalent `IS NULL`) and True otherwise. In this operating
+    mode, the given expression itself is also modified with these same semantics
+    and stored on the `sql` attribute.
+    """
+    def __init__(self, expression: ColumnElement, force_bool: bool = False):
+        self.sql = self._rephrase_as_boolean(expression) if force_bool else expression
+        self.serialized = tuple(self._serialize(expression, force_bool=force_bool))
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self.serialized == other.serialized
+
+    def evaluate(self, column_values: Dict[Column, Any]) -> Any:
+        """Evaluates the SQLAlchemy expression on the current column values."""
+        stack = Stack()
+        for itype, arity, value in self.serialized:
+            if itype is SymbolType.literal:
+                stack.push(value)
+            elif itype is SymbolType.column:
+                stack.push(column_values[value])
+            else:
+                stack.push(value(*stack.popn(arity)))
+        return stack.pop()
+
+    @property
+    def columns(self):
+        """Returns a set of columns used in the expression."""
+        coltype = SymbolType.column
+        return {symbol.value for symbol in self.serialized if symbol.type is coltype}
+
+    def _rephrase_as_boolean(self, expr: ColumnElement) -> ColumnElement:
+        """Rephrases SQL expression allowing boolean usage of non-bool columns.
+
+        This is done by converting bare non-Boolean columns (those not used in
+        a binary expression) in to "IS NOT NULL" clauses, and inversed columns
+        (~Column) into the negated form ("IS NULL").
+        """
+        if isinstance(expr, Column) and expr.type is not Boolean:
+            return expr.isnot(None)
+        elif isinstance(expr, UnaryExpression):
+            if expr.operator is operator.inv:
+                target = expr.element
+                if isinstance(target, Column) and target.type is not Boolean:
+                    return expr.element.is_(None)
+            return expr
+        elif isinstance(expr, BooleanClauseList):
+            expr.clauses = list(map(self._rephrase_as_boolean, expr.clauses))
+            return expr
+        return expr
+
+    def _serialize(self, expr, force_bool=False) -> Iterator[Symbol]:
+        """Serializes an SQLAlchemy expression to Python functions.
+
+        This takes an SQLAlchemy expression tree and converts it into an
+        equivalent set of Python Symbols. The generated format is that
+        of a reverse Polish notation. This allows the expression to be easily
+        evaluated with column value substitutions.
+        """
+        # Simple and direct value types
+        if isinstance(expr, BindParameter):
+            yield Symbol(expr.value)
+        elif isinstance(expr, Grouping):
+            value = [element.value for element in expr.element]
+            yield Symbol(value)
+        elif isinstance(expr, Null):
+            yield Symbol(None)
+        # Columns and column-wrapping functions
+        elif isinstance(expr, Column):
+            if force_bool and not isinstance(expr.type, Boolean):
+                yield from self._serialize(expr.isnot(None))
+            else:
+                yield Symbol(expr)
+        elif isinstance(expr, AsBoolean):
+            yield Symbol(expr.element)
+            if (func := OPERATOR_MAP[expr.operator]) is not None:
+                yield Symbol(func, arity=1)
+        elif isinstance(expr, UnaryExpression):
+            target = expr.element
+            target_is_column = isinstance(target, Column)
+            if force_bool and expr.operator == operator.inv and target_is_column:
+                yield from self._serialize(target.is_(None))
+            else:
+                yield from self._serialize(target, force_bool=force_bool)
+                yield Symbol(expr.operator, arity=1)
+        # Multi-clause expressions
+        elif isinstance(expr, BooleanClauseList):
+            for clause in expr.clauses:
+                yield from self._serialize(clause, force_bool=force_bool)
+            yield Symbol(expr.operator, arity=len(expr.clauses))
+        elif isinstance(expr, BinaryExpression):
+            yield from self._serialize(expr.right)
+            yield from self._serialize(expr.left)
+            yield Symbol(OPERATOR_MAP.get(expr.operator, expr.operator), arity=2)
+        else:
+            expr_type = type(expr).__name__
+            raise TypeError(f"Unsupported expression {expr} of type {expr_type}")
+
+
+class Stack:
+    def __init__(self):
+        self._stack = deque()
+
+    def push(self, frame: Any) -> None:
+        self._stack.append(frame)
+
+    def pop(self) -> Any:
+        return self._stack.pop()
+
+    def popn(self, size) -> Iterator[Any]:
+        return (self._stack.pop() for _ in range(size))
+
+
+class Symbol:
+    __slots__ = "value", "type", "arity"
+
+    def __init__(self, value: Any, arity: int = None):
+        self.value = value
+        self.type = self._determine_type(value)
+        self.arity = arity
+
+    def _determine_type(self, value: Any) -> SymbolType:
+        if isinstance(value, Column):
+            return SymbolType.column
+        if callable(value):
+            return SymbolType.operator
+        return SymbolType.literal
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return tuple(self) == tuple(other)
+
+    def __iter__(self):
+        yield from (self.type, self.arity, self.value)
+
+
+class SymbolType(Enum):
+    column = auto()
+    literal = auto()
+    operator = auto()

--- a/expression.py
+++ b/expression.py
@@ -41,6 +41,7 @@ class Expression:
     mode, the given expression itself is also modified with these same semantics
     and stored on the `sql` attribute.
     """
+
     def __init__(self, expression: ColumnElement, force_bool: bool = False):
         self.sql = self._rephrase_as_boolean(expression) if force_bool else expression
         self.serialized = tuple(self._serialize(expression, force_bool=force_bool))

--- a/test_column_flag.py
+++ b/test_column_flag.py
@@ -18,7 +18,7 @@ def test_flag_initial_value(Message, content, expected_value):
     assert empty_message.has_content == expected_value
 
 
-def test_flag_follows_column(Message):
+def test_flag_runtime_evaluation(Message):
     message = Message()
     message.content = "Spam spam spam"
     assert message.has_content
@@ -130,8 +130,8 @@ def test_table_inheritance_base(Booking):
     booking = Booking(paid_at=datetime.utcnow())
     assert booking.type == "standard"
     assert booking.is_paid
-    assert not hasattr(booking, 'cancelled_at')
-    assert not hasattr(booking, 'is_cancelled')
+    assert not hasattr(booking, "cancelled_at")
+    assert not hasattr(booking, "is_cancelled")
 
 
 def test_table_inheritance_subclass(Cancellable):

--- a/test_expression.py
+++ b/test_expression.py
@@ -1,0 +1,173 @@
+import pytest
+from sqlalchemy import Table, MetaData, Column, Boolean, Integer, Text, null
+
+from expression import Expression
+
+
+class TestBooleanExpressions:
+    BOOL = Table(
+        "bool_expr",
+        MetaData(),
+        Column("a", Boolean),
+        Column("b", Boolean),
+        Column("c", Boolean),
+    )
+
+    @pytest.fixture
+    def cols(self):
+        return self.BOOL.columns
+
+    @pytest.mark.parametrize(
+        "inputs, expected", [({BOOL.c.a: False}, False), ({BOOL.c.a: True}, True)]
+    )
+    def test_direct_bool(self, cols, inputs, expected):
+        expression = Expression(cols.a)
+        assert expression.evaluate(inputs) == expected
+
+    @pytest.mark.parametrize(
+        "inputs, expected", [({BOOL.c.a: False}, True), ({BOOL.c.a: True}, False)]
+    )
+    def test_negation(self, cols, inputs, expected):
+        expression = Expression(~cols.a)
+        assert expression.evaluate(inputs) == expected
+
+    @pytest.mark.parametrize(
+        "inputs, expected",
+        [
+            ({BOOL.c.a: False, BOOL.c.b: False}, False),
+            ({BOOL.c.a: True, BOOL.c.b: False}, False),
+            ({BOOL.c.a: False, BOOL.c.b: True}, False),
+            ({BOOL.c.a: True, BOOL.c.b: True}, True),
+        ],
+    )
+    def test_conjunction(self, cols, inputs, expected):
+        expression = Expression(cols.a & cols.b)
+        assert expression.evaluate(inputs) == expected
+
+    @pytest.mark.parametrize(
+        "inputs, expected",
+        [
+            ({BOOL.c.a: False, BOOL.c.b: False}, False),
+            ({BOOL.c.a: True, BOOL.c.b: False}, True),
+            ({BOOL.c.a: False, BOOL.c.b: True}, True),
+            ({BOOL.c.a: True, BOOL.c.b: True}, True),
+        ],
+    )
+    def test_disjunction(self, cols, inputs, expected):
+        expression = Expression(cols.a | cols.b)
+        assert expression.evaluate(inputs) == expected
+
+    @pytest.mark.parametrize(
+        "inputs, expected",
+        [
+            ({BOOL.c.a: False, BOOL.c.b: False, BOOL.c.c: False}, False),
+            ({BOOL.c.a: True, BOOL.c.b: False, BOOL.c.c: False}, True),
+            ({BOOL.c.a: False, BOOL.c.b: True, BOOL.c.c: False}, False),
+            ({BOOL.c.a: True, BOOL.c.b: True, BOOL.c.c: False}, False),
+            ({BOOL.c.a: False, BOOL.c.b: False, BOOL.c.c: True}, True),
+            ({BOOL.c.a: True, BOOL.c.b: False, BOOL.c.c: True}, True),
+            ({BOOL.c.a: False, BOOL.c.b: True, BOOL.c.c: True}, True),
+            ({BOOL.c.a: True, BOOL.c.b: True, BOOL.c.c: True}, True),
+        ],
+    )
+    def test_mixed_expression(self, cols, inputs, expected):
+        expression = Expression((cols.a & ~cols.b) | cols.c)
+        assert expression.evaluate(inputs) == expected
+
+
+class TestBooleanCoercion:
+    COERCE = Table(
+        "expr_coerce",
+        MetaData(),
+        Column("bool", Boolean),
+        Column("number", Integer),
+        Column("text", Text),
+    )
+
+    @pytest.mark.parametrize("column", [COERCE.c.number, COERCE.c.text])
+    def test_sql_equivalences(self, column):
+        left = Expression(column != null())
+        right = Expression(column.isnot(None))
+        assert left == right
+
+    @pytest.mark.parametrize("column", [COERCE.c.number, COERCE.c.text])
+    def test_coerce_simple_expression(self, column):
+        left = Expression(column, force_bool=True)
+        right = Expression(column.isnot(None))
+        assert left == right
+
+    @pytest.mark.parametrize("column", [COERCE.c.number, COERCE.c.text])
+    def test_coerce_negated_expression(self, column):
+        left = Expression(~column, force_bool=True)
+        right = Expression(column.is_(None))
+        assert left == right
+
+    def test_do_not_coerce_bool_column(self):
+        left = Expression(~self.COERCE.c.bool, force_bool=True)
+        right = Expression(~self.COERCE.c.bool)
+        assert left == right
+
+    def test_do_not_coerce_negated_bool_column(self):
+        left = Expression(self.COERCE.c.bool, force_bool=True)
+        right = Expression(self.COERCE.c.bool)
+        assert left == right
+
+    @pytest.mark.parametrize("column", [COERCE.c.number, COERCE.c.text])
+    def test_do_not_coerce_nonbool_expr(self, column):
+        left = Expression(~column.in_(["foo", "bar"]), force_bool=True)
+        right = Expression(~column.in_(["foo", "bar"]))
+        assert left == right
+
+
+class TestMathExpressions:
+    MATH = Table(
+        "expr_math",
+        MetaData(),
+        Column("a", Integer),
+        Column("b", Integer),
+        Column("c", Integer),
+    )
+
+    @pytest.fixture
+    def cols(self):
+        return self.MATH.columns
+
+    @pytest.mark.parametrize(
+        "inputs, expected",
+        [
+            ({MATH.c.a: 0, MATH.c.b: 0}, 0),
+            ({MATH.c.a: 2, MATH.c.b: 0}, 2),
+            ({MATH.c.a: 0, MATH.c.b: 3}, 3),
+            ({MATH.c.a: 5, MATH.c.b: 5}, 10),
+            ({MATH.c.a: -2, MATH.c.b: -2}, -4),
+        ],
+    )
+    def test_addition(self, cols, inputs, expected):
+        addition = Expression(cols.a + cols.b)
+        assert addition.evaluate(inputs) == expected
+
+    @pytest.mark.parametrize(
+        "inputs, expected",
+        [
+            ({MATH.c.a: 0, MATH.c.b: 0}, 0),
+            ({MATH.c.a: 2, MATH.c.b: 0}, 2),
+            ({MATH.c.a: 0, MATH.c.b: 3}, -3),
+            ({MATH.c.a: 5, MATH.c.b: -5}, 10),
+        ],
+    )
+    def test_subtraction(self, cols, inputs, expected):
+        subtraction = Expression(cols.a - cols.b)
+        assert subtraction.evaluate(inputs) == expected
+
+    @pytest.mark.parametrize(
+        "inputs, expected",
+        [
+            ({MATH.c.a: 0, MATH.c.b: 0, MATH.c.c: 0}, 0),
+            ({MATH.c.a: 2, MATH.c.b: 3, MATH.c.c: 0}, 6),
+            ({MATH.c.a: 3, MATH.c.b: 4, MATH.c.c: 6}, 6),
+            ({MATH.c.a: 3, MATH.c.b: -3, MATH.c.c: -3}, -6),
+        ],
+    )
+    def test_mixed_match(self, cols, inputs, expected):
+        multmin = Expression(cols.a * cols.b - cols.c)
+        assert multmin.evaluate(inputs) == expected

--- a/test_multi_column_flag.py
+++ b/test_multi_column_flag.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "sent_at, delivered_at, expected",
+    [
+        pytest.param(None, None, False, id="not shipped"),
+        pytest.param(datetime(2020, 1, 1), None, True, id="in transit"),
+        pytest.param(None, datetime(2020, 1, 1), False, id="magic arrival"),
+    ],
+)
+def test_flag_initial_value(Message, sent_at, delivered_at, expected):
+    message = Message(sent_at=sent_at, delivered_at=delivered_at)
+    assert message.in_transit == expected
+
+
+def test_flag_runtime_evaluation(Message):
+    message = Message(content="Spam")
+    message.sent_at = datetime(2020, 1, 1)
+    assert message.in_transit
+
+    message.delivered_at = datetime(2020, 1, 2)
+    assert not message.in_transit
+
+
+def test_flag_after_database_read(Message, session):
+    msg = Message(sent_at=datetime(2020, 1, 1))
+    session.add(msg)
+    session.commit()
+    assert msg.in_transit
+
+
+def test_flag_select_expr(Message, session):
+    monday = datetime(2020, 6, 1)
+    tuesday = datetime(2020, 6, 2)
+    session.add(Message(sent_at=monday))
+    session.add(Message(sent_at=monday, delivered_at=tuesday))
+    session.add(Message(sent_at=tuesday))
+    assert session.query(Message).filter(Message.in_transit).count() == 2


### PR DESCRIPTION
Adds an `Expression` class that parses an SQLAlchemy expression to an RPN serialization of positional arguments and Python functions that can be evaluated using column substitution values. This allows for (some, maybe most, definitely not all) SQLAlchemy expressions to be evaluated at runtime. This includes a coercion to boolean for non-boolean columns. The boolean value for these columns is their inequality to `None` (that is, True when they contain a value _other_ than `None`).

This allows for multi-column expressions to be evaluated in the `column_flag` getter. The simple example for this (provided in the tests) is a property `in_transit = column_flag(sent_at & ~delivered_at)`