### PR TITLE
Test completeness

### DIFF
--- a/expression.py
+++ b/expression.py
@@ -20,6 +20,7 @@ from sqlalchemy.sql.schema import Column
 from sqlalchemy.sql.sqltypes import Boolean
 
 OPERATOR_MAP = {
+    operators.in_op: lambda left, right: left in right,
     operators.is_: operator.eq,
     operators.isnot: operator.ne,
     operators.istrue: None,

--- a/expression.py
+++ b/expression.py
@@ -112,6 +112,8 @@ class Expression:
                 yield from self._serialize(clause, force_bool=force_bool)
             yield Symbol(expr.operator, arity=len(expr.clauses))
         elif isinstance(expr, BinaryExpression):
+            if isinstance(expr.operator, operators.custom_op):
+                raise TypeError(f"Unsupported operator {expr.operator}")
             yield from self._serialize(expr.right)
             yield from self._serialize(expr.left)
             yield Symbol(OPERATOR_MAP.get(expr.operator, expr.operator), arity=2)

--- a/test_expression.py
+++ b/test_expression.py
@@ -1,5 +1,5 @@
 import pytest
-from sqlalchemy import Column, Boolean, Integer, Text, null
+from sqlalchemy import Column, Boolean, Integer, Text, func, null
 
 from expression import Expression
 
@@ -10,6 +10,44 @@ INT_A = Column("int_a", Integer)
 INT_B = Column("int_b", Integer)
 INT_C = Column("int_c", Integer)
 TEXT = Column("text", Text)
+
+
+# Equality and comparability
+def test_expression_self_equality():
+    expr = Expression(BOOL_A & (INT_A > 5))
+    assert expr == expr
+
+
+def test_expression_equality():
+    expr = BOOL_A & (INT_A > 5)
+    left = Expression(expr)
+    right = Expression(expr)
+    assert left is not right
+    assert left == right
+
+
+def test_expression_inequality():
+    assert Expression(BOOL_A) != Expression(~BOOL_A)
+
+
+@pytest.mark.parametrize("other", [[], [None], 0, 100, True, False, None])
+def test_expression_and_symbol_comparability(other):
+    expr = Expression(BOOL_A & (INT_A > 5))
+    assert expr != other
+    for symbol in expr.serialized:
+        assert symbol == symbol
+        assert symbol != other
+
+
+# Serialization limits
+def test_serlialize_unsupported_expression():
+    with pytest.raises(TypeError, match="Unsupported expression"):
+        Expression(func.exp(INT_A, 2))
+
+
+def test_serlialize_unsupported_opeator():
+    with pytest.raises(TypeError, match="Unsupported operator"):
+        Expression(INT_A.op("^")(INT_A))
 
 
 # Coercion

--- a/test_expression.py
+++ b/test_expression.py
@@ -137,6 +137,25 @@ def test_multiplication():
     assert expr.evaluate({INT_A: 4, INT_B: -3}) == -12
 
 
+def test_bitwise_inversion():
+    expr = Expression(~INT_A)
+    assert expr.evaluate({INT_A: 127}) == -128
+    assert expr.evaluate({INT_A: -128}) == 127
+
+
 def test_mixed_math():
     expr = Expression((INT_A * INT_B) + (INT_A / INT_C))
     assert expr.evaluate({INT_A: 8, INT_B: 2, INT_C: 4}) == 18
+
+
+# Test additional expression evaluation
+def test_evaluate_bind_param_equals():
+    expr = Expression(INT_A == 5)
+    assert not expr.evaluate({INT_A: 4})
+    assert expr.evaluate({INT_A: 5})
+
+
+def test_evaluate_bind_param_contains():
+    expr = Expression(INT_A.in_([1, 2, 3, 4, 5]))
+    assert expr.evaluate({INT_A: 3})
+    assert not expr.evaluate({INT_A: 6})

--- a/test_expression.py
+++ b/test_expression.py
@@ -1,173 +1,142 @@
 import pytest
-from sqlalchemy import Table, MetaData, Column, Boolean, Integer, Text, null
+from sqlalchemy import Column, Boolean, Integer, Text, null
 
 from expression import Expression
 
-
-class TestBooleanExpressions:
-    BOOL = Table(
-        "bool_expr",
-        MetaData(),
-        Column("a", Boolean),
-        Column("b", Boolean),
-        Column("c", Boolean),
-    )
-
-    @pytest.fixture
-    def cols(self):
-        return self.BOOL.columns
-
-    @pytest.mark.parametrize(
-        "inputs, expected", [({BOOL.c.a: False}, False), ({BOOL.c.a: True}, True)]
-    )
-    def test_direct_bool(self, cols, inputs, expected):
-        expression = Expression(cols.a)
-        assert expression.evaluate(inputs) == expected
-
-    @pytest.mark.parametrize(
-        "inputs, expected", [({BOOL.c.a: False}, True), ({BOOL.c.a: True}, False)]
-    )
-    def test_negation(self, cols, inputs, expected):
-        expression = Expression(~cols.a)
-        assert expression.evaluate(inputs) == expected
-
-    @pytest.mark.parametrize(
-        "inputs, expected",
-        [
-            ({BOOL.c.a: False, BOOL.c.b: False}, False),
-            ({BOOL.c.a: True, BOOL.c.b: False}, False),
-            ({BOOL.c.a: False, BOOL.c.b: True}, False),
-            ({BOOL.c.a: True, BOOL.c.b: True}, True),
-        ],
-    )
-    def test_conjunction(self, cols, inputs, expected):
-        expression = Expression(cols.a & cols.b)
-        assert expression.evaluate(inputs) == expected
-
-    @pytest.mark.parametrize(
-        "inputs, expected",
-        [
-            ({BOOL.c.a: False, BOOL.c.b: False}, False),
-            ({BOOL.c.a: True, BOOL.c.b: False}, True),
-            ({BOOL.c.a: False, BOOL.c.b: True}, True),
-            ({BOOL.c.a: True, BOOL.c.b: True}, True),
-        ],
-    )
-    def test_disjunction(self, cols, inputs, expected):
-        expression = Expression(cols.a | cols.b)
-        assert expression.evaluate(inputs) == expected
-
-    @pytest.mark.parametrize(
-        "inputs, expected",
-        [
-            ({BOOL.c.a: False, BOOL.c.b: False, BOOL.c.c: False}, False),
-            ({BOOL.c.a: True, BOOL.c.b: False, BOOL.c.c: False}, True),
-            ({BOOL.c.a: False, BOOL.c.b: True, BOOL.c.c: False}, False),
-            ({BOOL.c.a: True, BOOL.c.b: True, BOOL.c.c: False}, False),
-            ({BOOL.c.a: False, BOOL.c.b: False, BOOL.c.c: True}, True),
-            ({BOOL.c.a: True, BOOL.c.b: False, BOOL.c.c: True}, True),
-            ({BOOL.c.a: False, BOOL.c.b: True, BOOL.c.c: True}, True),
-            ({BOOL.c.a: True, BOOL.c.b: True, BOOL.c.c: True}, True),
-        ],
-    )
-    def test_mixed_expression(self, cols, inputs, expected):
-        expression = Expression((cols.a & ~cols.b) | cols.c)
-        assert expression.evaluate(inputs) == expected
+BOOL_A = Column("bool_a", Boolean)
+BOOL_B = Column("bool_b", Boolean)
+BOOL_C = Column("bool_c", Boolean)
+INT_A = Column("int_a", Integer)
+INT_B = Column("int_b", Integer)
+INT_C = Column("int_c", Integer)
+TEXT = Column("text", Text)
 
 
-class TestBooleanCoercion:
-    COERCE = Table(
-        "expr_coerce",
-        MetaData(),
-        Column("bool", Boolean),
-        Column("number", Integer),
-        Column("text", Text),
-    )
-
-    @pytest.mark.parametrize("column", [COERCE.c.number, COERCE.c.text])
-    def test_sql_equivalences(self, column):
-        left = Expression(column != null())
-        right = Expression(column.isnot(None))
-        assert left == right
-
-    @pytest.mark.parametrize("column", [COERCE.c.number, COERCE.c.text])
-    def test_coerce_simple_expression(self, column):
-        left = Expression(column, force_bool=True)
-        right = Expression(column.isnot(None))
-        assert left == right
-
-    @pytest.mark.parametrize("column", [COERCE.c.number, COERCE.c.text])
-    def test_coerce_negated_expression(self, column):
-        left = Expression(~column, force_bool=True)
-        right = Expression(column.is_(None))
-        assert left == right
-
-    def test_do_not_coerce_bool_column(self):
-        left = Expression(~self.COERCE.c.bool, force_bool=True)
-        right = Expression(~self.COERCE.c.bool)
-        assert left == right
-
-    def test_do_not_coerce_negated_bool_column(self):
-        left = Expression(self.COERCE.c.bool, force_bool=True)
-        right = Expression(self.COERCE.c.bool)
-        assert left == right
-
-    @pytest.mark.parametrize("column", [COERCE.c.number, COERCE.c.text])
-    def test_do_not_coerce_nonbool_expr(self, column):
-        left = Expression(~column.in_(["foo", "bar"]), force_bool=True)
-        right = Expression(~column.in_(["foo", "bar"]))
-        assert left == right
+# Coercion
+@pytest.mark.parametrize("column", [INT_A, TEXT])
+def test_sql_equivalences(column):
+    left = Expression(column != null())
+    right = Expression(column.isnot(None))
+    assert left == right
 
 
-class TestMathExpressions:
-    MATH = Table(
-        "expr_math",
-        MetaData(),
-        Column("a", Integer),
-        Column("b", Integer),
-        Column("c", Integer),
-    )
+@pytest.mark.parametrize("column", [INT_A, TEXT])
+def test_coerce_simple_expression(column):
+    left = Expression(column, force_bool=True)
+    right = Expression(column.isnot(None))
+    assert left == right
 
-    @pytest.fixture
-    def cols(self):
-        return self.MATH.columns
 
-    @pytest.mark.parametrize(
-        "inputs, expected",
-        [
-            ({MATH.c.a: 0, MATH.c.b: 0}, 0),
-            ({MATH.c.a: 2, MATH.c.b: 0}, 2),
-            ({MATH.c.a: 0, MATH.c.b: 3}, 3),
-            ({MATH.c.a: 5, MATH.c.b: 5}, 10),
-            ({MATH.c.a: -2, MATH.c.b: -2}, -4),
-        ],
-    )
-    def test_addition(self, cols, inputs, expected):
-        addition = Expression(cols.a + cols.b)
-        assert addition.evaluate(inputs) == expected
+@pytest.mark.parametrize("column", [INT_A, TEXT])
+def test_coerce_negated_expression(column):
+    left = Expression(~column, force_bool=True)
+    right = Expression(column.is_(None))
+    assert left == right
 
-    @pytest.mark.parametrize(
-        "inputs, expected",
-        [
-            ({MATH.c.a: 0, MATH.c.b: 0}, 0),
-            ({MATH.c.a: 2, MATH.c.b: 0}, 2),
-            ({MATH.c.a: 0, MATH.c.b: 3}, -3),
-            ({MATH.c.a: 5, MATH.c.b: -5}, 10),
-        ],
-    )
-    def test_subtraction(self, cols, inputs, expected):
-        subtraction = Expression(cols.a - cols.b)
-        assert subtraction.evaluate(inputs) == expected
 
-    @pytest.mark.parametrize(
-        "inputs, expected",
-        [
-            ({MATH.c.a: 0, MATH.c.b: 0, MATH.c.c: 0}, 0),
-            ({MATH.c.a: 2, MATH.c.b: 3, MATH.c.c: 0}, 6),
-            ({MATH.c.a: 3, MATH.c.b: 4, MATH.c.c: 6}, 6),
-            ({MATH.c.a: 3, MATH.c.b: -3, MATH.c.c: -3}, -6),
-        ],
-    )
-    def test_mixed_match(self, cols, inputs, expected):
-        multmin = Expression(cols.a * cols.b - cols.c)
-        assert multmin.evaluate(inputs) == expected
+def test_do_not_coerce_bool_column():
+    left = Expression(~BOOL_A, force_bool=True)
+    right = Expression(~BOOL_A)
+    assert left == right
+
+
+def test_do_not_coerce_negated_bool_column():
+    left = Expression(BOOL_A, force_bool=True)
+    right = Expression(BOOL_A)
+    assert left == right
+
+
+@pytest.mark.parametrize("column", [INT_A, TEXT])
+def test_do_not_coerce_nonbool_expr(column):
+    left = Expression(~column.in_(["foo", "bar"]), force_bool=True)
+    right = Expression(~column.in_(["foo", "bar"]))
+    assert left == right
+
+
+# Boolean expression evaluation
+@pytest.mark.parametrize(
+    "inputs, expected", [({BOOL_A: False}, False), ({BOOL_A: True}, True)]
+)
+def test_bool_expr_direct_column(inputs, expected):
+    expression = Expression(BOOL_A)
+    assert expression.evaluate(inputs) == expected
+
+
+@pytest.mark.parametrize(
+    "inputs, expected", [({BOOL_A: False}, True), ({BOOL_A: True}, False)]
+)
+def test_bool_expr_negation(inputs, expected):
+    expression = Expression(~BOOL_A)
+    assert expression.evaluate(inputs) == expected
+
+
+@pytest.mark.parametrize(
+    "inputs, expected",
+    [
+        ({BOOL_A: False, BOOL_B: False}, False),
+        ({BOOL_A: True, BOOL_B: False}, False),
+        ({BOOL_A: False, BOOL_B: True}, False),
+        ({BOOL_A: True, BOOL_B: True}, True),
+    ],
+)
+def test_bool_expr_conjunction(inputs, expected):
+    expression = Expression(BOOL_A & BOOL_B)
+    assert expression.evaluate(inputs) == expected
+
+
+@pytest.mark.parametrize(
+    "inputs, expected",
+    [
+        ({BOOL_A: False, BOOL_B: False}, False),
+        ({BOOL_A: True, BOOL_B: False}, True),
+        ({BOOL_A: False, BOOL_B: True}, True),
+        ({BOOL_A: True, BOOL_B: True}, True),
+    ],
+)
+def test_bool_expr_disjunction(inputs, expected):
+    expression = Expression(BOOL_A | BOOL_B)
+    assert expression.evaluate(inputs) == expected
+
+
+@pytest.mark.parametrize(
+    "inputs, expected",
+    [
+        ({BOOL_A: False, BOOL_B: False, BOOL_C: False}, False),
+        ({BOOL_A: True, BOOL_B: False, BOOL_C: False}, True),
+        ({BOOL_A: False, BOOL_B: True, BOOL_C: False}, False),
+        ({BOOL_A: True, BOOL_B: True, BOOL_C: False}, False),
+        ({BOOL_A: False, BOOL_B: False, BOOL_C: True}, True),
+        ({BOOL_A: True, BOOL_B: False, BOOL_C: True}, True),
+        ({BOOL_A: False, BOOL_B: True, BOOL_C: True}, True),
+        ({BOOL_A: True, BOOL_B: True, BOOL_C: True}, True),
+    ],
+)
+def test_bool_expr_mixed(inputs, expected):
+    expression = Expression((BOOL_A & ~BOOL_B) | BOOL_C)
+    assert expression.evaluate(inputs) == expected
+
+
+# Math expression evaluation
+def test_addition():
+    expr = Expression(INT_A + INT_B)
+    assert expr.evaluate({INT_A: 2, INT_B: -10}) == -8
+
+
+def test_subtraction():
+    expr = Expression(INT_A - INT_B)
+    assert expr.evaluate({INT_A: 2, INT_B: 5}) == -3
+
+
+def test_division():
+    expr = Expression(INT_A / INT_B)
+    assert expr.evaluate({INT_A: 4, INT_B: 2}) == 2
+
+
+def test_multiplication():
+    expr = Expression(INT_A * INT_B)
+    assert expr.evaluate({INT_A: 4, INT_B: -3}) == -12
+
+
+def test_mixed_math():
+    expr = Expression((INT_A * INT_B) + (INT_A / INT_C))
+    assert expr.evaluate({INT_A: 8, INT_B: 2, INT_C: 4}) == 18

--- a/test_multi_column_flag.py
+++ b/test_multi_column_flag.py
@@ -1,6 +1,9 @@
 from datetime import datetime
 
 import pytest
+from sqlalchemy import Column, Integer
+
+from sqlalchemy_column_flag import column_flag
 
 
 @pytest.mark.parametrize(
@@ -39,3 +42,11 @@ def test_flag_select_expr(Message, session):
     session.add(Message(sent_at=monday, delivered_at=tuesday))
     session.add(Message(sent_at=tuesday))
     assert session.query(Message).filter(Message.in_transit).count() == 2
+
+
+def test_multi_column_no_default():
+    col_one = Column("foo", Integer)
+    col_two = Column("bar", Integer)
+
+    with pytest.raises(TypeError, match="default for multi-column expression"):
+        column_flag(col_one & col_two, default="baz")


### PR DESCRIPTION
* Refactors tests for `expression` module to be simple functions using a shared collection of columns;
* Adds some tests for equality checks of `Expression` and `Symbol` classes;
* Adds checks for the limits of serialization based on Python evaluation capabilities;
* Adds support for simple `Column.in_(list)` statements.

This achieves full line-based coverage of the `expression` module and near -complete coverage of the `sqlalchemy_column_flag` module :tada: 