### PR TITLE
Full test coverage

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -2,27 +2,20 @@ import nox
 
 
 @nox.session(python="3.8")
-def black(session):
-    args = session.posargs or (".",)
-    session.install("black")
-    session.run("black", "--check", *args)
-
-
-@nox.session(python="3.8")
-def flake(session):
-    session.install("flake8")
+def lint(session):
+    session.install("flake8", "flake8-black")
     session.run("flake8", *session.posargs)
 
 
 @nox.session(python="3.8")
-def mypy(session):
+def type(session):
     session.install("mypy", "sqlalchemy-stubs")
     session.run("mypy", *session.posargs)
 
 
 @nox.session(python="3.8")
 @nox.parametrize("sqla", ["1.1", "1.2", "1.3"])
-def tests(session, sqla):
+def test(session, sqla):
     args = session.posargs or ["--cov"]
     session.run("poetry", "install", external=True)
     session.install(f"sqlalchemy=={sqla}")

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,9 +14,10 @@ def type(session):
 
 
 @nox.session(python="3.8")
-@nox.parametrize("sqla", ["1.1", "1.2", "1.3"])
-def test(session, sqla):
+@nox.parametrize("sqlalchemy", ["1.0", "1.1", "1.2", "1.3"])
+def test(session, sqlalchemy):
     args = session.posargs or ["--cov"]
-    session.run("poetry", "install", external=True)
-    session.install(f"sqlalchemy=={sqla}")
+    session.install("pytest", "coverage[toml]", "pytest-cov")
+    session.install(f"sqlalchemy=={sqlalchemy}")
+    session.install(".")
     session.run("pytest", *args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ source = ["sqlalchemy_hybrid_utils"]
 [tool.coverage.report]
 fail_under = 100
 show_missing = true
-exclude_lines = ["if TYPE_CHECKING:"]
+exclude_lines = ["# pragma: no cover", "if TYPE_CHECKING:"]
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/src/sqlalchemy_hybrid_utils/__init__.py
+++ b/src/sqlalchemy_hybrid_utils/__init__.py
@@ -7,13 +7,13 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapper, mapperlib
 from sqlalchemy.sql.elements import ClauseElement
 
-from .expression import Expression
+from .expression import Expression, rephrase_as_boolean
 from .typing import ColumnDefaults, ColumnValues, MapperTargets
 
 
 class DerivedColumn:
     def __init__(self, expression: ClauseElement, default: Any = None):
-        self.expression = Expression(expression, force_bool=True)
+        self.expression = Expression(expression)
         self.default = default
         self.targets: MapperTargets = {}
         if len(self.expression.columns) > 1 and self.default is not None:
@@ -82,5 +82,6 @@ class DerivedColumn:
 
 
 def column_flag(expression: ClauseElement, **options: Any) -> hybrid_property:
+    expression = rephrase_as_boolean(expression)
     derived = DerivedColumn(expression, **options)
     return derived.create_hybrid()

--- a/src/sqlalchemy_hybrid_utils/__init__.py
+++ b/src/sqlalchemy_hybrid_utils/__init__.py
@@ -43,7 +43,7 @@ class DerivedColumn:
                     if column in mapper.columns.values():
                         attr = mapper.get_property_by_column(column)
                         target_names.add(attr.key)
-            if len(target_names) != 1:
+            if len(target_names) != 1:  # pragma: no cover
                 raise TypeError(
                     f"Unable to find unambiguous mapped attribute "
                     f"name for {column!r}: {target_names}."

--- a/src/sqlalchemy_hybrid_utils/expression.py
+++ b/src/sqlalchemy_hybrid_utils/expression.py
@@ -45,9 +45,9 @@ class Expression:
     and stored on the `sql` attribute.
     """
 
-    def __init__(self, expression: ClauseElement, force_bool: bool = False):
-        self.sql = rephrase_as_boolean(expression) if force_bool else expression
-        self.serialized = tuple(self._serialize(self.sql))
+    def __init__(self, expression: ClauseElement):
+        self.serialized = tuple(self._serialize(expression))
+        self.sql = expression
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, type(self)):

--- a/src/sqlalchemy_hybrid_utils/expression.py
+++ b/src/sqlalchemy_hybrid_utils/expression.py
@@ -132,10 +132,15 @@ class Stack:
 class Symbol:
     __slots__ = "value", "type", "arity"
 
-    def __init__(self, value: Any, arity: Optional[int] = None):
+    def __init__(self, value: Any, *, arity: Optional[int] = None):
         self.value = value
         self.type = self._determine_type(value)
         self.arity = arity
+        if self.type is SymbolType.operator:
+            if self.arity is None:
+                raise ValueError(f"Arity required for Symbol of type {self.type}.")
+        elif self.arity is not None:
+            raise ValueError(f"Arity not allowed for non-operator type {self.type}.")
 
     def _determine_type(self, value: Any) -> SymbolType:
         if isinstance(value, Column):

--- a/tests/test_column_flag.py
+++ b/tests/test_column_flag.py
@@ -107,6 +107,22 @@ def test_default_at_creation_sql_func(Message, session):
     assert datetime_equal(message.sent_at, datetime.utcnow())
 
 
+@pytest.mark.parametrize(
+    "column, flag",
+    [
+        ("sent_at", "is_sent"),
+        ("sent_at", "is_sent_scalar"),
+        ("delivered_at", "is_delivered"),
+    ],
+)
+def test_default_false(Message, column, flag):
+    message = Message(content="spam", **{column: datetime.utcnow()})
+    assert getattr(message, column) is not None
+    assert getattr(message, flag)
+    setattr(message, flag, False)
+    assert getattr(message, column) is None
+
+
 def test_assign_readonly_error(Message):
     message = Message(content="Spam")
     with pytest.raises(AttributeError):

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -34,9 +34,6 @@ def test_expression_inequality():
 def test_expression_and_symbol_comparability(other):
     expr = Expression(BOOL_A & (INT_A > 5))
     assert expr != other
-    for symbol in expr.serialized:
-        assert symbol == symbol
-        assert symbol != other
 
 
 # Serialization limits

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -1,5 +1,5 @@
 import pytest
-from sqlalchemy import Column, Boolean, Integer, Text, func, null
+from sqlalchemy import Column, Boolean, Integer, Text, func
 
 from sqlalchemy_hybrid_utils.expression import Expression
 
@@ -45,47 +45,6 @@ def test_serlialize_unsupported_expression():
 def test_serlialize_unsupported_opeator():
     with pytest.raises(TypeError, match="Unsupported operator"):
         Expression(INT_A.op("^")(INT_A))
-
-
-# Coercion
-@pytest.mark.parametrize("column", [INT_A, TEXT])
-def test_sql_equivalences(column):
-    left = Expression(column != null())
-    right = Expression(column.isnot(None))
-    assert left == right
-
-
-@pytest.mark.parametrize("column", [INT_A, TEXT])
-def test_coerce_simple_expression(column):
-    left = Expression(column, force_bool=True)
-    right = Expression(column.isnot(None))
-    assert left == right
-
-
-@pytest.mark.parametrize("column", [INT_A, TEXT])
-def test_coerce_negated_expression(column):
-    left = Expression(~column, force_bool=True)
-    right = Expression(column.is_(None))
-    assert left == right
-
-
-def test_do_not_coerce_bool_column():
-    left = Expression(~BOOL_A, force_bool=True)
-    right = Expression(~BOOL_A)
-    assert left == right
-
-
-def test_do_not_coerce_negated_bool_column():
-    left = Expression(BOOL_A, force_bool=True)
-    right = Expression(BOOL_A)
-    assert left == right
-
-
-@pytest.mark.parametrize("column", [INT_A, TEXT])
-def test_do_not_coerce_nonbool_expr(column):
-    left = Expression(~column.in_(["foo", "bar"]), force_bool=True)
-    right = Expression(~column.in_(["foo", "bar"]))
-    assert left == right
 
 
 # Boolean expression evaluation

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -1,0 +1,42 @@
+import pytest
+from sqlalchemy import Column, Boolean
+
+from sqlalchemy_hybrid_utils.expression import Symbol
+
+BOOL_A = Column("bool_a", Boolean)
+BOOL_B = Column("bool_b", Boolean)
+
+
+def test_symbol_equality():
+    left = Symbol(BOOL_A)
+    right = Symbol(BOOL_A)
+    assert left is not right
+    assert left == right
+
+
+def test_symbol_inequality():
+    left = Symbol(BOOL_A)
+    right = Symbol(BOOL_B)
+    assert left != right
+
+
+@pytest.mark.parametrize("other", [[], [None], 0, 100, "bool_a", True, False, None])
+def test_symbol_other_type_inequality(other):
+    assert Symbol(BOOL_A) != other
+
+
+@pytest.mark.parametrize("value", [BOOL_A, [1, 2], None, 5])
+def test_symbol_arity_operator_only(value):
+    with pytest.raises(ValueError, match="Arity not allowed"):
+        Symbol(value, arity=2)
+
+
+def test_symbol_operator_arity_required():
+    with pytest.raises(ValueError, match="Arity required"):
+        Symbol(all)
+
+
+@pytest.mark.parametrize("value, arity", [(BOOL_A, None), (any, 2), (5, None)])
+def test_symbol_representation(value, arity):
+    symbol = Symbol(value, arity=arity)
+    assert repr(symbol)


### PR DESCRIPTION
Adds additional tests to bring coverage up to 100% (minus a case where a column is mapped twice). Alters the `noxfile` to clean up the sessions and speed up testing, as well as testing all of the supported SQLAlchemy versions.

Refactors `Expression` to no longer have a `force_bool` parameter that triggers query rephrasing. Removing this removes a bunch of required tests and removes a level of redundancy in the tests (all of these parts are tested as part of query rephrasing).