### PR TITLE
Improved attribute resolution

### DIFF
--- a/example.py
+++ b/example.py
@@ -2,7 +2,7 @@ from sqlalchemy import Column, Integer, DateTime, Text, create_engine, func
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session
 
-from sqlalchemy_column_flag import column_flag
+from sqlalchemy_hybrid_utils import column_flag
 
 Base = declarative_base()
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -94,7 +94,7 @@ description = "Code coverage measurement for Python"
 name = "coverage"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "5.1"
+version = "5.2"
 
 [package.extras]
 toml = ["toml"]
@@ -105,7 +105,7 @@ description = "Distribution utilities"
 name = "distlib"
 optional = false
 python-versions = "*"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 category = "dev"
@@ -307,7 +307,7 @@ description = "Database Abstraction Library"
 name = "sqlalchemy"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.3.17"
+version = "1.3.18"
 
 [package.extras]
 mssql = ["pyodbc"]
@@ -363,11 +363,11 @@ description = "Virtual Python Environment builder"
 name = "virtualenv"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "20.0.25"
+version = "20.0.26"
 
 [package.dependencies]
 appdirs = ">=1.4.3,<2"
-distlib = ">=0.3.0,<1"
+distlib = ">=0.3.1,<1"
 filelock = ">=3.0.0,<4"
 six = ">=1.9.0,<2"
 
@@ -421,40 +421,44 @@ colorlog = [
     {file = "colorlog-4.1.0.tar.gz", hash = "sha256:30aaef5ab2a1873dec5da38fd6ba568fa761c9fa10b40241027fa3edea47f3d2"},
 ]
 coverage = [
-    {file = "coverage-5.1-cp27-cp27m-macosx_10_12_x86_64.whl", hash = "sha256:0cb4be7e784dcdc050fc58ef05b71aa8e89b7e6636b99967fadbdba694cf2b65"},
-    {file = "coverage-5.1-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:c317eaf5ff46a34305b202e73404f55f7389ef834b8dbf4da09b9b9b37f76dd2"},
-    {file = "coverage-5.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b83835506dfc185a319031cf853fa4bb1b3974b1f913f5bb1a0f3d98bdcded04"},
-    {file = "coverage-5.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5f2294dbf7875b991c381e3d5af2bcc3494d836affa52b809c91697449d0eda6"},
-    {file = "coverage-5.1-cp27-cp27m-win32.whl", hash = "sha256:de807ae933cfb7f0c7d9d981a053772452217df2bf38e7e6267c9cbf9545a796"},
-    {file = "coverage-5.1-cp27-cp27m-win_amd64.whl", hash = "sha256:bf9cb9a9fd8891e7efd2d44deb24b86d647394b9705b744ff6f8261e6f29a730"},
-    {file = "coverage-5.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:acf3763ed01af8410fc36afea23707d4ea58ba7e86a8ee915dfb9ceff9ef69d0"},
-    {file = "coverage-5.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:dec5202bfe6f672d4511086e125db035a52b00f1648d6407cc8e526912c0353a"},
-    {file = "coverage-5.1-cp35-cp35m-macosx_10_12_x86_64.whl", hash = "sha256:7a5bdad4edec57b5fb8dae7d3ee58622d626fd3a0be0dfceda162a7035885ecf"},
-    {file = "coverage-5.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1601e480b9b99697a570cea7ef749e88123c04b92d84cedaa01e117436b4a0a9"},
-    {file = "coverage-5.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:dbe8c6ae7534b5b024296464f387d57c13caa942f6d8e6e0346f27e509f0f768"},
-    {file = "coverage-5.1-cp35-cp35m-win32.whl", hash = "sha256:a027ef0492ede1e03a8054e3c37b8def89a1e3c471482e9f046906ba4f2aafd2"},
-    {file = "coverage-5.1-cp35-cp35m-win_amd64.whl", hash = "sha256:0e61d9803d5851849c24f78227939c701ced6704f337cad0a91e0972c51c1ee7"},
-    {file = "coverage-5.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:2d27a3f742c98e5c6b461ee6ef7287400a1956c11421eb574d843d9ec1f772f0"},
-    {file = "coverage-5.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:66460ab1599d3cf894bb6baee8c684788819b71a5dc1e8fa2ecc152e5d752019"},
-    {file = "coverage-5.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5c542d1e62eece33c306d66fe0a5c4f7f7b3c08fecc46ead86d7916684b36d6c"},
-    {file = "coverage-5.1-cp36-cp36m-win32.whl", hash = "sha256:2742c7515b9eb368718cd091bad1a1b44135cc72468c731302b3d641895b83d1"},
-    {file = "coverage-5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:dead2ddede4c7ba6cb3a721870f5141c97dc7d85a079edb4bd8d88c3ad5b20c7"},
-    {file = "coverage-5.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:01333e1bd22c59713ba8a79f088b3955946e293114479bbfc2e37d522be03355"},
-    {file = "coverage-5.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e1ea316102ea1e1770724db01998d1603ed921c54a86a2efcb03428d5417e489"},
-    {file = "coverage-5.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:adeb4c5b608574a3d647011af36f7586811a2c1197c861aedb548dd2453b41cd"},
-    {file = "coverage-5.1-cp37-cp37m-win32.whl", hash = "sha256:782caea581a6e9ff75eccda79287daefd1d2631cc09d642b6ee2d6da21fc0a4e"},
-    {file = "coverage-5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:00f1d23f4336efc3b311ed0d807feb45098fc86dee1ca13b3d6768cdab187c8a"},
-    {file = "coverage-5.1-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:402e1744733df483b93abbf209283898e9f0d67470707e3c7516d84f48524f55"},
-    {file = "coverage-5.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:a3f3654d5734a3ece152636aad89f58afc9213c6520062db3978239db122f03c"},
-    {file = "coverage-5.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6402bd2fdedabbdb63a316308142597534ea8e1895f4e7d8bf7476c5e8751fef"},
-    {file = "coverage-5.1-cp38-cp38-win32.whl", hash = "sha256:8fa0cbc7ecad630e5b0f4f35b0f6ad419246b02bc750de7ac66db92667996d24"},
-    {file = "coverage-5.1-cp38-cp38-win_amd64.whl", hash = "sha256:79a3cfd6346ce6c13145731d39db47b7a7b859c0272f02cdb89a3bdcbae233a0"},
-    {file = "coverage-5.1-cp39-cp39-win32.whl", hash = "sha256:a82b92b04a23d3c8a581fc049228bafde988abacba397d57ce95fe95e0338ab4"},
-    {file = "coverage-5.1-cp39-cp39-win_amd64.whl", hash = "sha256:bb28a7245de68bf29f6fb199545d072d1036a1917dca17a1e75bbb919e14ee8e"},
-    {file = "coverage-5.1.tar.gz", hash = "sha256:f90bfc4ad18450c80b024036eaf91e4a246ae287701aaa88eaebebf150868052"},
+    {file = "coverage-5.2-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:d9ad0a988ae20face62520785ec3595a5e64f35a21762a57d115dae0b8fb894a"},
+    {file = "coverage-5.2-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:4bb385a747e6ae8a65290b3df60d6c8a692a5599dc66c9fa3520e667886f2e10"},
+    {file = "coverage-5.2-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:9702e2cb1c6dec01fb8e1a64c015817c0800a6eca287552c47a5ee0ebddccf62"},
+    {file = "coverage-5.2-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:42fa45a29f1059eda4d3c7b509589cc0343cd6bbf083d6118216830cd1a51613"},
+    {file = "coverage-5.2-cp27-cp27m-win32.whl", hash = "sha256:41d88736c42f4a22c494c32cc48a05828236e37c991bd9760f8923415e3169e4"},
+    {file = "coverage-5.2-cp27-cp27m-win_amd64.whl", hash = "sha256:bbb387811f7a18bdc61a2ea3d102be0c7e239b0db9c83be7bfa50f095db5b92a"},
+    {file = "coverage-5.2-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:3740b796015b889e46c260ff18b84683fa2e30f0f75a171fb10d2bf9fb91fc70"},
+    {file = "coverage-5.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ebf2431b2d457ae5217f3a1179533c456f3272ded16f8ed0b32961a6d90e38ee"},
+    {file = "coverage-5.2-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:d54d7ea74cc00482a2410d63bf10aa34ebe1c49ac50779652106c867f9986d6b"},
+    {file = "coverage-5.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:87bdc8135b8ee739840eee19b184804e5d57f518578ffc797f5afa2c3c297913"},
+    {file = "coverage-5.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:ed9a21502e9223f563e071759f769c3d6a2e1ba5328c31e86830368e8d78bc9c"},
+    {file = "coverage-5.2-cp35-cp35m-win32.whl", hash = "sha256:509294f3e76d3f26b35083973fbc952e01e1727656d979b11182f273f08aa80b"},
+    {file = "coverage-5.2-cp35-cp35m-win_amd64.whl", hash = "sha256:ca63dae130a2e788f2b249200f01d7fa240f24da0596501d387a50e57aa7075e"},
+    {file = "coverage-5.2-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:5c74c5b6045969b07c9fb36b665c9cac84d6c174a809fc1b21bdc06c7836d9a0"},
+    {file = "coverage-5.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c32aa13cc3fe86b0f744dfe35a7f879ee33ac0a560684fef0f3e1580352b818f"},
+    {file = "coverage-5.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1e58fca3d9ec1a423f1b7f2aa34af4f733cbfa9020c8fe39ca451b6071237405"},
+    {file = "coverage-5.2-cp36-cp36m-win32.whl", hash = "sha256:3b2c34690f613525672697910894b60d15800ac7e779fbd0fccf532486c1ba40"},
+    {file = "coverage-5.2-cp36-cp36m-win_amd64.whl", hash = "sha256:a4d511012beb967a39580ba7d2549edf1e6865a33e5fe51e4dce550522b3ac0e"},
+    {file = "coverage-5.2-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:32ecee61a43be509b91a526819717d5e5650e009a8d5eda8631a59c721d5f3b6"},
+    {file = "coverage-5.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6f91b4492c5cde83bfe462f5b2b997cdf96a138f7c58b1140f05de5751623cf1"},
+    {file = "coverage-5.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bfcc811883699ed49afc58b1ed9f80428a18eb9166422bce3c31a53dba00fd1d"},
+    {file = "coverage-5.2-cp37-cp37m-win32.whl", hash = "sha256:60a3d36297b65c7f78329b80120f72947140f45b5c7a017ea730f9112b40f2ec"},
+    {file = "coverage-5.2-cp37-cp37m-win_amd64.whl", hash = "sha256:12eaccd86d9a373aea59869bc9cfa0ab6ba8b1477752110cb4c10d165474f703"},
+    {file = "coverage-5.2-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:d82db1b9a92cb5c67661ca6616bdca6ff931deceebb98eecbd328812dab52032"},
+    {file = "coverage-5.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:214eb2110217f2636a9329bc766507ab71a3a06a8ea30cdeebb47c24dce5972d"},
+    {file = "coverage-5.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8a3decd12e7934d0254939e2bf434bf04a5890c5bf91a982685021786a08087e"},
+    {file = "coverage-5.2-cp38-cp38-win32.whl", hash = "sha256:1dcebae667b73fd4aa69237e6afb39abc2f27520f2358590c1b13dd90e32abe7"},
+    {file = "coverage-5.2-cp38-cp38-win_amd64.whl", hash = "sha256:f50632ef2d749f541ca8e6c07c9928a37f87505ce3a9f20c8446ad310f1aa87b"},
+    {file = "coverage-5.2-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:7403675df5e27745571aba1c957c7da2dacb537c21e14007ec3a417bf31f7f3d"},
+    {file = "coverage-5.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:0fc4e0d91350d6f43ef6a61f64a48e917637e1dcfcba4b4b7d543c628ef82c2d"},
+    {file = "coverage-5.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:25fe74b5b2f1b4abb11e103bb7984daca8f8292683957d0738cd692f6a7cc64c"},
+    {file = "coverage-5.2-cp39-cp39-win32.whl", hash = "sha256:d67599521dff98ec8c34cd9652cbcfe16ed076a2209625fca9dc7419b6370e5c"},
+    {file = "coverage-5.2-cp39-cp39-win_amd64.whl", hash = "sha256:10f2a618a6e75adf64329f828a6a5b40244c1c50f5ef4ce4109e904e69c71bd2"},
+    {file = "coverage-5.2.tar.gz", hash = "sha256:1874bdc943654ba46d28f179c1846f5710eda3aeb265ff029e0ac2b52daae404"},
 ]
 distlib = [
-    {file = "distlib-0.3.0.zip", hash = "sha256:2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21"},
+    {file = "distlib-0.3.1-py2.py3-none-any.whl", hash = "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb"},
+    {file = "distlib-0.3.1.zip", hash = "sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"},
 ]
 filelock = [
     {file = "filelock-3.0.12-py3-none-any.whl", hash = "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"},
@@ -560,34 +564,34 @@ six = [
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
 ]
 sqlalchemy = [
-    {file = "SQLAlchemy-1.3.17-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:fe01bac7226499aedf472c62fa3b85b2c619365f3f14dd222ffe4f3aa91e5f98"},
-    {file = "SQLAlchemy-1.3.17-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:b50f45d0e82b4562f59f0e0ca511f65e412f2a97d790eea5f60e34e5f1aabc9a"},
-    {file = "SQLAlchemy-1.3.17-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:ce2646e4c0807f3461be0653502bb48c6e91a5171d6e450367082c79e12868bf"},
-    {file = "SQLAlchemy-1.3.17-cp27-cp27m-win32.whl", hash = "sha256:e4e2664232005bd306f878b0f167a31f944a07c4de0152c444f8c61bbe3cfb38"},
-    {file = "SQLAlchemy-1.3.17-cp27-cp27m-win_amd64.whl", hash = "sha256:925b4fe5e7c03ed76912b75a9a41dfd682d59c0be43bce88d3b27f7f5ba028fb"},
-    {file = "SQLAlchemy-1.3.17-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:869bbb637de58ab0a912b7f20e9192132f9fbc47fc6b5111cd1e0f6cdf5cf9b0"},
-    {file = "SQLAlchemy-1.3.17-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:703c002277f0fbc3c04d0ae4989a174753a7554b2963c584ce2ec0cddcf2bc53"},
-    {file = "SQLAlchemy-1.3.17-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:eb4fcf7105bf071c71068c6eee47499ab8d4b8f5a11fc35147c934f0faa60f23"},
-    {file = "SQLAlchemy-1.3.17-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:8d01e949a5d22e5c4800d59b50617c56125fc187fbeb8fa423e99858546de616"},
-    {file = "SQLAlchemy-1.3.17-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:a9e75e49a0f1583eee0ce93270232b8e7bb4b1edc89cc70b07600d525aef4f43"},
-    {file = "SQLAlchemy-1.3.17-cp35-cp35m-win32.whl", hash = "sha256:a87d496884f40c94c85a647c385f4fd5887941d2609f71043e2b73f2436d9c65"},
-    {file = "SQLAlchemy-1.3.17-cp35-cp35m-win_amd64.whl", hash = "sha256:6cd157ce74a911325e164441ff2d9b4e244659a25b3146310518d83202f15f7a"},
-    {file = "SQLAlchemy-1.3.17-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:27e2efc8f77661c9af2681755974205e7462f1ae126f498f4fe12a8b24761d15"},
-    {file = "SQLAlchemy-1.3.17-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:31c043d5211aa0e0773821fcc318eb5cbe2ec916dfbc4c6eea0c5188971988eb"},
-    {file = "SQLAlchemy-1.3.17-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:a9030cd30caf848a13a192c5e45367e3c6f363726569a56e75dc1151ee26d859"},
-    {file = "SQLAlchemy-1.3.17-cp36-cp36m-win32.whl", hash = "sha256:f502ef245c492b391e0e23e94cba030ab91722dcc56963c85bfd7f3441ea2bbe"},
-    {file = "SQLAlchemy-1.3.17-cp36-cp36m-win_amd64.whl", hash = "sha256:128bc917ed20d78143a45024455ff0aed7d3b96772eba13d5dbaf9cc57e5c41b"},
-    {file = "SQLAlchemy-1.3.17-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:2a12f8be25b9ea3d1d5b165202181f2b7da4b3395289000284e5bb86154ce87c"},
-    {file = "SQLAlchemy-1.3.17-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e8aa395482728de8bdcca9cc0faf3765ab483e81e01923aaa736b42f0294f570"},
-    {file = "SQLAlchemy-1.3.17-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:f35248f7e0d63b234a109dd72fbfb4b5cb6cb6840b221d0df0ecbf54ab087654"},
-    {file = "SQLAlchemy-1.3.17-cp37-cp37m-win32.whl", hash = "sha256:ce1ddaadee913543ff0154021d31b134551f63428065168e756d90bdc4c686f5"},
-    {file = "SQLAlchemy-1.3.17-cp37-cp37m-win_amd64.whl", hash = "sha256:9cb1819008f0225a7c066cac8bb0cf90847b2c4a6eb9ebb7431dbd00c56c06c5"},
-    {file = "SQLAlchemy-1.3.17-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:65eb3b03229f684af0cf0ad3bcc771970c1260a82a791a8d07bffb63d8c95bcc"},
-    {file = "SQLAlchemy-1.3.17-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8a0e0cd21da047ea10267c37caf12add400a92f0620c8bc09e4a6531a765d6d7"},
-    {file = "SQLAlchemy-1.3.17-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:b7878e59ec31f12d54b3797689402ee3b5cfcb5598f2ebf26491732758751908"},
-    {file = "SQLAlchemy-1.3.17-cp38-cp38-win32.whl", hash = "sha256:ce6c3d18b2a8ce364013d47b9cad71db815df31d55918403f8db7d890c9d07ae"},
-    {file = "SQLAlchemy-1.3.17-cp38-cp38-win_amd64.whl", hash = "sha256:ed375a79f06cad285166e5be74745df1ed6845c5624aafadec4b7a29c25866ef"},
-    {file = "SQLAlchemy-1.3.17.tar.gz", hash = "sha256:156a27548ba4e1fed944ff9fcdc150633e61d350d673ae7baaf6c25c04ac1f71"},
+    {file = "SQLAlchemy-1.3.18-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:f11c2437fb5f812d020932119ba02d9e2bc29a6eca01a055233a8b449e3e1e7d"},
+    {file = "SQLAlchemy-1.3.18-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:0ec575db1b54909750332c2e335c2bb11257883914a03bc5a3306a4488ecc772"},
+    {file = "SQLAlchemy-1.3.18-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:f57be5673e12763dd400fea568608700a63ce1c6bd5bdbc3cc3a2c5fdb045274"},
+    {file = "SQLAlchemy-1.3.18-cp27-cp27m-win32.whl", hash = "sha256:8cac7bb373a5f1423e28de3fd5fc8063b9c8ffe8957dc1b1a59cb90453db6da1"},
+    {file = "SQLAlchemy-1.3.18-cp27-cp27m-win_amd64.whl", hash = "sha256:adad60eea2c4c2a1875eb6305a0b6e61a83163f8e233586a4d6a55221ef984fe"},
+    {file = "SQLAlchemy-1.3.18-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:57aa843b783179ab72e863512e14bdcba186641daf69e4e3a5761d705dcc35b1"},
+    {file = "SQLAlchemy-1.3.18-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:621f58cd921cd71ba6215c42954ffaa8a918eecd8c535d97befa1a8acad986dd"},
+    {file = "SQLAlchemy-1.3.18-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:fc728ece3d5c772c196fd338a99798e7efac7a04f9cb6416299a3638ee9a94cd"},
+    {file = "SQLAlchemy-1.3.18-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:736d41cfebedecc6f159fc4ac0769dc89528a989471dc1d378ba07d29a60ba1c"},
+    {file = "SQLAlchemy-1.3.18-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:427273b08efc16a85aa2b39892817e78e3ed074fcb89b2a51c4979bae7e7ba98"},
+    {file = "SQLAlchemy-1.3.18-cp35-cp35m-win32.whl", hash = "sha256:cbe1324ef52ff26ccde2cb84b8593c8bf930069dfc06c1e616f1bfd4e47f48a3"},
+    {file = "SQLAlchemy-1.3.18-cp35-cp35m-win_amd64.whl", hash = "sha256:8fd452dc3d49b3cc54483e033de6c006c304432e6f84b74d7b2c68afa2569ae5"},
+    {file = "SQLAlchemy-1.3.18-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:e89e0d9e106f8a9180a4ca92a6adde60c58b1b0299e1b43bd5e0312f535fbf33"},
+    {file = "SQLAlchemy-1.3.18-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:6ac2558631a81b85e7fb7a44e5035347938b0a73f5fdc27a8566777d0792a6a4"},
+    {file = "SQLAlchemy-1.3.18-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:87fad64529cde4f1914a5b9c383628e1a8f9e3930304c09cf22c2ae118a1280e"},
+    {file = "SQLAlchemy-1.3.18-cp36-cp36m-win32.whl", hash = "sha256:e4624d7edb2576cd72bb83636cd71c8ce544d8e272f308bd80885056972ca299"},
+    {file = "SQLAlchemy-1.3.18-cp36-cp36m-win_amd64.whl", hash = "sha256:89494df7f93b1836cae210c42864b292f9b31eeabca4810193761990dc689cce"},
+    {file = "SQLAlchemy-1.3.18-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:716754d0b5490bdcf68e1e4925edc02ac07209883314ad01a137642ddb2056f1"},
+    {file = "SQLAlchemy-1.3.18-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:50c4ee32f0e1581828843267d8de35c3298e86ceecd5e9017dc45788be70a864"},
+    {file = "SQLAlchemy-1.3.18-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:d98bc827a1293ae767c8f2f18be3bb5151fd37ddcd7da2a5f9581baeeb7a3fa1"},
+    {file = "SQLAlchemy-1.3.18-cp37-cp37m-win32.whl", hash = "sha256:0942a3a0df3f6131580eddd26d99071b48cfe5aaf3eab2783076fbc5a1c1882e"},
+    {file = "SQLAlchemy-1.3.18-cp37-cp37m-win_amd64.whl", hash = "sha256:16593fd748944726540cd20f7e83afec816c2ac96b082e26ae226e8f7e9688cf"},
+    {file = "SQLAlchemy-1.3.18-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:c26f95e7609b821b5f08a72dab929baa0d685406b953efd7c89423a511d5c413"},
+    {file = "SQLAlchemy-1.3.18-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:512a85c3c8c3995cc91af3e90f38f460da5d3cade8dc3a229c8e0879037547c9"},
+    {file = "SQLAlchemy-1.3.18-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d05c4adae06bd0c7f696ae3ec8d993ed8ffcc4e11a76b1b35a5af8a099bd2284"},
+    {file = "SQLAlchemy-1.3.18-cp38-cp38-win32.whl", hash = "sha256:109581ccc8915001e8037b73c29590e78ce74be49ca0a3630a23831f9e3ed6c7"},
+    {file = "SQLAlchemy-1.3.18-cp38-cp38-win_amd64.whl", hash = "sha256:8619b86cb68b185a778635be5b3e6018623c0761dde4df2f112896424aa27bd8"},
+    {file = "SQLAlchemy-1.3.18.tar.gz", hash = "sha256:da2fb75f64792c1fc64c82313a00c728a7c301efe6a60b7a9fe35b16b4368ce7"},
 ]
 sqlalchemy-stubs = [
     {file = "sqlalchemy-stubs-0.3.tar.gz", hash = "sha256:a3318c810697164e8c818aa2d90bac570c1a0e752ced3ec25455b309c0bee8fd"},
@@ -626,8 +630,8 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.2.tar.gz", hash = "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.0.25-py2.py3-none-any.whl", hash = "sha256:ffffcb3c78a671bb3d590ac3bc67c081ea2188befeeb058870cba13e7f82911b"},
-    {file = "virtualenv-20.0.25.tar.gz", hash = "sha256:f332ba0b2dfbac9f6b1da9f11224f0036b05cdb4df23b228527c2a2d5504aeed"},
+    {file = "virtualenv-20.0.26-py2.py3-none-any.whl", hash = "sha256:c11a475400e98450403c0364eb3a2d25d42f71cf1493da64390487b666de4324"},
+    {file = "virtualenv-20.0.26.tar.gz", hash = "sha256:e10cc66f40cbda459720dfe1d334c4dc15add0d80f09108224f171006a97a172"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/src/sqlalchemy_hybrid_utils/__init__.py
+++ b/src/sqlalchemy_hybrid_utils/__init__.py
@@ -7,7 +7,11 @@ from .derived_column import DerivedColumn
 from .expression import Expression, rephrase_as_boolean
 
 
-def column_flag(expr: ClauseElement, default: Any = None) -> hybrid_property:
+def column_flag(
+    expr: ClauseElement, default: Any = None, prefetch_attribute_names: bool = True
+) -> hybrid_property:
     expression = Expression(rephrase_as_boolean(expr))
-    derived = DerivedColumn(expression, default=default)
+    derived = DerivedColumn(
+        expression, default=default, prefetch_attribute_names=prefetch_attribute_names
+    )
     return derived.create_hybrid()

--- a/src/sqlalchemy_hybrid_utils/derived_column.py
+++ b/src/sqlalchemy_hybrid_utils/derived_column.py
@@ -2,22 +2,36 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-from sqlalchemy.event import listen
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import Mapper, mapperlib
 
 from .expression import Expression
-from .typing import ColumnDefaults, ColumnValues, MapperTargets
+from .resolver import (
+    AttributeResolver,
+    PrefetchedAttributeResolver,
+)
+from .typing import (
+    ColumnDefaults,
+    ExpressionEvaluation,
+    ResolveAttrName,
+    ResolveAttrValues,
+)
 
 
 class DerivedColumn:
-    def __init__(self, expression: Expression, default: Any = None):
+    def __init__(
+        self,
+        expression: Expression,
+        default: Any = None,
+        prefetch_attribute_names: bool = True,
+    ):
         self.expression = expression
         self.default = default
-        self.targets: MapperTargets = {}
+        if not prefetch_attribute_names:
+            self.resolver = AttributeResolver(expression.columns)
+        else:
+            self.resolver = PrefetchedAttributeResolver(expression.columns)
         if len(self.expression.columns) > 1 and self.default is not None:
             raise TypeError("Cannot use default for multi-column expression.")
-        listen(Mapper, "after_configured", self._set_static_target_attr)
 
     def _default_functions(self) -> ColumnDefaults:
         setter = self.default
@@ -25,50 +39,30 @@ class DerivedColumn:
             setter = lambda: self.default  # noqa
         return {True: setter, False: lambda: None}
 
-    def _set_static_target_attr(self) -> None:
-        """Looks up the attribute name that points to the tracked column.
-
-        When multiple mappers exist for the same table, this may lead to an
-        unresolvable conflict, but only if the column's attribute name differs
-        between mappers.
-
-        In the case of single table inheritance, the column property might be
-        absent on some mappers, but has the same name on those that contain it.
-        """
-        for column in self.expression.columns:
-            target_names = set()
-            for mapper in mapperlib._mapper_registry:  # type: ignore[attr-defined]
-                if column.table in mapper.tables:
-                    if column in mapper.columns.values():
-                        attr = mapper.get_property_by_column(column)
-                        target_names.add(attr.key)
-            if len(target_names) != 1:  # pragma: no cover
-                raise TypeError(
-                    f"Unable to find unambiguous mapped attribute "
-                    f"name for {column!r}: {target_names}."
-                )
-            self.targets[column] = next(iter(target_names))
-
-    def column_values(self, orm_obj: Any) -> ColumnValues:
-        """Returns values of column-attributes for given ORM object."""
-        return {col: getattr(orm_obj, attr) for col, attr in self.targets.items()}
-
-    def make_getter(self) -> Callable[[Any, DerivedColumn], Any]:
-        def _fget(self: Any, outer: DerivedColumn = self) -> Any:
-            return outer.expression.evaluate(outer.column_values(self))
+    def make_getter(
+        self,
+    ) -> Callable[[Any, ExpressionEvaluation, ResolveAttrValues], Any]:
+        def _fget(
+            self: Any,
+            evaluate: ExpressionEvaluation = self.expression.evaluate,
+            values: ResolveAttrValues = self.resolver.values,
+        ) -> Any:
+            return evaluate(values(self))
 
         return _fget
 
-    def make_setter(self,) -> Callable[[Any, Any, MapperTargets, ColumnDefaults], None]:
+    def make_setter(
+        self,
+    ) -> Callable[[Any, Any, ResolveAttrName, ColumnDefaults], None]:
         def _fset(
             self: Any,
             value: Any,
-            targets: MapperTargets = self.targets,
+            target_name: ResolveAttrName = self.resolver.single_name,
             defaults: ColumnDefaults = self._default_functions(),
         ) -> None:
             if not isinstance(value, bool):
                 raise TypeError("Flag only accepts boolean values")
-            setattr(self, next(iter(targets.values())), defaults[value]())
+            setattr(self, target_name(self), defaults[value]())
 
         return _fset
 

--- a/src/sqlalchemy_hybrid_utils/resolver.py
+++ b/src/sqlalchemy_hybrid_utils/resolver.py
@@ -1,0 +1,60 @@
+from collections import defaultdict
+from typing import Any, Type
+
+from sqlalchemy.event import listen
+from sqlalchemy.inspection import inspect
+from sqlalchemy.orm import Mapper
+
+from .typing import (
+    ColumnSet,
+    ColumnValues,
+    MapperTargets,
+)
+
+
+class AttributeResolver:
+    """A runtime inspection-based resolver for attribute names and values."""
+
+    def __init__(self, columns: ColumnSet):
+        self._columns = columns
+
+    def single_name(self, orm_obj: Any) -> str:
+        """Returns the first (and only) attribute name for __fset__."""
+        mapper = inspect(orm_obj).mapper
+        column = next(iter(self._columns))
+        return mapper.get_property_by_column(column).key
+
+    def values(self, orm_obj: Any) -> ColumnValues:
+        """Returns values of column-attributes for given ORM object."""
+        mapper = inspect(orm_obj).mapper
+        getter = mapper.get_property_by_column
+        return {col: getattr(orm_obj, getter(col).key) for col in self._columns}
+
+
+class PrefetchedAttributeResolver(AttributeResolver):
+    def __init__(self, columns: ColumnSet):
+        super().__init__(columns)
+        self._targets: MapperTargets = defaultdict(dict)
+        listen(Mapper, "mapper_configured", self._resolve_mapped_attribute_names)
+
+    def _resolve_mapped_attribute_names(
+        self, mapper: Mapper, mapped_class: Type[Any]
+    ) -> None:
+        """Looks up attribute name on the mapped class for each tracked column.
+
+        This column->attribute name mapping is created separately for each
+        mapped class. This allows multiple mapped classes against the same
+        table to have different attribute names to refer to a column.
+        """
+        for column in self._columns:
+            if column in mapper.columns.values():
+                attr = mapper.get_property_by_column(column)
+                self._targets[mapped_class][column] = attr.key
+
+    def single_name(self, orm_obj: Any) -> str:
+        """Returns the first (and only) attribute name for __fset__."""
+        return next(iter(self._targets[type(orm_obj)].values()))
+
+    def values(self, orm_obj: Any) -> ColumnValues:
+        targets = self._targets[type(orm_obj)]
+        return {col: getattr(orm_obj, attr) for col, attr in targets.items()}

--- a/src/sqlalchemy_hybrid_utils/typing.py
+++ b/src/sqlalchemy_hybrid_utils/typing.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Set, TYPE_CHECKING
+from typing import Any, Callable, Dict, Set, Type, TYPE_CHECKING
 
 from sqlalchemy.sql.schema import Column
 
@@ -10,4 +10,7 @@ else:
 ColumnDefaults = Dict[bool, Any]
 ColumnValues = Dict[ColType, Any]
 ColumnSet = Set[ColType]
-MapperTargets = Dict[ColType, str]
+ExpressionEvaluation = Callable[[Any], Any]
+MapperTargets = Dict[Type[Any], Dict[ColType, str]]
+ResolveAttrName = Callable[[Any], str]
+ResolveAttrValues = Callable[[Any], ColumnValues]

--- a/tests/test_multi_column_flag.py
+++ b/tests/test_multi_column_flag.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 import pytest
-from sqlalchemy import Column, Integer
 
 from sqlalchemy_hybrid_utils import column_flag
 
@@ -44,9 +43,9 @@ def test_flag_select_expr(Message, session):
     assert session.query(Message).filter(Message.in_transit).count() == 2
 
 
-def test_multi_column_no_default():
-    col_one = Column("foo", Integer)
-    col_two = Column("bar", Integer)
+def test_multi_column_no_default(Message):
+    col_one = Message.__table__.c.content
+    col_two = Message.__table__.c.sent_at
 
     with pytest.raises(TypeError, match="default for multi-column expression"):
         column_flag(col_one & col_two, default="baz")

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,0 +1,114 @@
+import pytest
+from sqlalchemy import Table, MetaData, Column, Integer, Text
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.inspection import inspect
+from sqlalchemy.orm import mapper
+
+from sqlalchemy_hybrid_utils import column_flag
+from sqlalchemy_hybrid_utils.resolver import (
+    AttributeResolver,
+    PrefetchedAttributeResolver,
+)
+
+
+@pytest.fixture
+def Thing():
+    class Thing(declarative_base()):  # type: ignore
+        __tablename__ = "resolver_thing"
+        id = Column(Integer, primary_key=True)
+        named = Column(Text)
+        renamed = Column("unnamed", Text)
+
+    return Thing
+
+
+@pytest.fixture
+def column_map(Thing):
+    columns = Thing.__table__.columns
+    return {"named": columns.named, "renamed": columns.unnamed}
+
+
+@pytest.fixture(params=[AttributeResolver, PrefetchedAttributeResolver])
+def resolver_type(request):
+    """Returns each of the resolver types in turn."""
+    return request.param
+
+
+@pytest.fixture
+def make_resolver(Thing, resolver_type):
+    """Returns a factory to create and initializes AttributeResolvers."""
+
+    def _resolver(columns):
+        resolver = resolver_type(set(columns))
+        # This ensures prefetching gets triggered. This event is usually dispatched
+        # after mapper configuration, run shortly after the class containing the
+        # DerivedColumn with the PrefetchedAttributeResolver is created, or shortly
+        # before its first use. For tests however, this event needs to be triggered
+        # (configure_mappers() is smart about not doing work when there is none)
+        mapper = inspect(Thing).mapper
+        mapper.dispatch.mapper_configured(mapper, Thing)
+        return resolver
+
+    return _resolver
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.param({}, id="uninitialized"),
+        pytest.param({"named": None, "renamed": None}, id="explicitly nulled"),
+        pytest.param({"named": "ham", "renamed": "spam"}, id="basic strings"),
+    ],
+)
+def test_resolve_simple_values(Thing, column_map, make_resolver, params):
+    thing = Thing(**params)
+    resolver = make_resolver(column_map.values())
+    resolved_values = resolver.values(thing)
+    for attr_name, column in column_map.items():
+        assert getattr(thing, attr_name) == resolved_values[column]
+
+
+def test_single_name_getter(Thing, column_map, make_resolver):
+    thing = Thing()
+    for attr_name, column in column_map.items():
+        resolver = make_resolver({column})
+        assert resolver.single_name(thing) == attr_name
+
+
+def test_ambiguous_attribute_names_across_mappers(make_resolver):
+    """Ambiguously mapped column works normally for AttributeResolver."""
+    table = Table("test", MetaData(), Column("value", Text, primary_key=True))
+
+    class Base:
+        def __init__(self, value):
+            self.value = value
+
+    class Alias:
+        def __init__(self, value):
+            self.alias = value
+
+    resolver = make_resolver({table.c.value})
+    mapper(Base, table)
+    mapper(Alias, table, properties={"alias": table.c.value})
+    base = Base("spam")
+    alias = Alias("eggs")
+    assert resolver.single_name(base) == "value"
+    assert resolver.single_name(alias) == "alias"
+    assert resolver.values(base) == {table.c.value: "spam"}
+    assert resolver.values(alias) == {table.c.value: "eggs"}
+
+
+@pytest.mark.parametrize("prefetch", [False, True])
+def test_column_flag_prefetch_switch(prefetch):
+    class Mapped(declarative_base()):  # type: ignore
+        __tablename__ = "mapped"
+        value = Column(Text, primary_key=True)
+        has_value = column_flag(
+            value, default="eggs", prefetch_attribute_names=prefetch
+        )
+
+    mapped = Mapped()
+    assert not mapped.has_value
+    mapped.has_value = True
+    assert mapped.has_value
+    assert mapped.value == "eggs"


### PR DESCRIPTION
This PR factors out the task of attribute-value resolution currently performed in `DerivedColumn`. It identifies two distinct requirements for that task:

1. single-column to name resolution for use with `default` clauses and
2. creation of _column -> mapped object value_ mappings for `Expression` evaluation.

Two implementations are provided:

1. `AttributeResolver` which is a straightforward approach based on the runtime inspection API in SQLAlchemy;
2. `PrefetchedAttributeResolver`, an improved implementation of the pre-existing resolver. It improves on the previous approach by adding support for multiple mapped classes against the same table, even if these mapped classes use different names to refer to the same column (that is, `A.foo -> table.c.value` as well as `B.bar -> table.c.value`)

The `column_flag` and `DerivedColumn` have been extended with a `prefetch_attribute_names` parameter (defaults `True`), to control whether the prefetch or runtime approach is used. Coverage exceptions have been removed and tests have been added to clarify both the API and prevent regressions.