### PR TITLE
Improve Expression evaluation performance

### DIFF
--- a/src/sqlalchemy_hybrid_utils/derived_column.py
+++ b/src/sqlalchemy_hybrid_utils/derived_column.py
@@ -35,11 +35,7 @@ class DerivedColumn:
         """Returns a getter function, evaluating the expression in bound scope."""
         evaluate = self.expression.evaluate
         values = self.resolver.values
-
-        def _fget(self: Any) -> Any:
-            return evaluate(values(self))
-
-        return _fget
+        return lambda orm_obj: evaluate(values(orm_obj))
 
     def make_setter(self) -> Callable[[Any, Any], None]:
         """Returns a setter function setting default values based on given booleans."""

--- a/src/sqlalchemy_hybrid_utils/expression.py
+++ b/src/sqlalchemy_hybrid_utils/expression.py
@@ -69,6 +69,10 @@ class Expression:
                 stack_push(value)
             elif itype is SymbolType.column:
                 stack_push(column_values[value])
+            elif arity == 1:
+                stack_push(value(stack_pop()))
+            elif arity == 2:
+                stack_push(value(stack_pop(), stack_pop()))
             else:
                 stack_push(value(*(stack_pop() for _ in range(arity))))
         return stack_pop()

--- a/src/sqlalchemy_hybrid_utils/expression.py
+++ b/src/sqlalchemy_hybrid_utils/expression.py
@@ -68,7 +68,7 @@ class Expression:
             if itype is SymbolType.literal:
                 stack_push(value)
             elif itype is SymbolType.column:
-                stack_push(column_values[value])
+                stack_push(column_values(value))
             elif arity == 1:
                 stack_push(value(stack_pop()))
             elif arity == 2:

--- a/src/sqlalchemy_hybrid_utils/expression.py
+++ b/src/sqlalchemy_hybrid_utils/expression.py
@@ -105,6 +105,12 @@ class Expression:
             yield from self._serialize(target)
             yield Symbol(expr.operator, arity=1)
         # Multi-clause expressions
+        elif isinstance(expr, BinaryExpression):
+            if isinstance(expr.operator, operators.custom_op):
+                raise TypeError(f"Unsupported operator {expr.operator}")
+            yield from self._serialize(expr.right)
+            yield from self._serialize(expr.left)
+            yield Symbol(OPERATOR_MAP.get(expr.operator, expr.operator), arity=2)
         elif isinstance(expr, BooleanClauseList):
             yield from chain.from_iterable(map(self._serialize, expr.clauses))
             if (arity := len(expr.clauses)) == 0:
@@ -113,12 +119,6 @@ class Expression:
                 yield Symbol(expr.operator, arity=arity)
             else:
                 yield Symbol(BOOLEAN_MULTICLAUSE_OPERATORS[expr.operator], arity=arity)
-        elif isinstance(expr, BinaryExpression):
-            if isinstance(expr.operator, operators.custom_op):
-                raise TypeError(f"Unsupported operator {expr.operator}")
-            yield from self._serialize(expr.right)
-            yield from self._serialize(expr.left)
-            yield Symbol(OPERATOR_MAP.get(expr.operator, expr.operator), arity=2)
         else:
             expr_type = type(expr).__name__
             raise TypeError(f"Unsupported expression {expr} of type {expr_type}")

--- a/src/sqlalchemy_hybrid_utils/expression.py
+++ b/src/sqlalchemy_hybrid_utils/expression.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import operator
 from collections import deque
 from enum import Enum, auto
+from itertools import chain
 from typing import Any, Deque, Iterator, Optional
 
 from sqlalchemy.sql import operators
@@ -105,8 +106,7 @@ class Expression:
             yield Symbol(expr.operator, arity=1)
         # Multi-clause expressions
         elif isinstance(expr, BooleanClauseList):
-            for clause in expr.clauses:
-                yield from self._serialize(clause)
+            yield from chain.from_iterable(map(self._serialize, expr.clauses))
             if (arity := len(expr.clauses)) == 0:
                 yield Symbol(True)
             elif arity == 2:

--- a/src/sqlalchemy_hybrid_utils/resolver.py
+++ b/src/sqlalchemy_hybrid_utils/resolver.py
@@ -24,7 +24,7 @@ class AttributeResolver:
         """Returns values of column-attributes for given ORM object."""
         mapper = inspect(orm_obj).mapper
         getter = mapper.get_property_by_column
-        return {col: getattr(orm_obj, getter(col).key) for col in self._columns}
+        return lambda col: getattr(orm_obj, getter(col).key)
 
 
 class PrefetchedAttributeResolver(AttributeResolver):
@@ -53,4 +53,4 @@ class PrefetchedAttributeResolver(AttributeResolver):
 
     def values(self, orm_obj: Any) -> ColumnValues:
         targets = self._targets[type(orm_obj)]
-        return {col: getattr(orm_obj, attr) for col, attr in targets.items()}
+        return lambda col: getattr(orm_obj, targets[col])

--- a/src/sqlalchemy_hybrid_utils/typing.py
+++ b/src/sqlalchemy_hybrid_utils/typing.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, Set, Type
+from typing import TYPE_CHECKING, Any, Callable, Dict, Set, Type
 
 from sqlalchemy.sql.schema import Column
 
@@ -8,6 +8,6 @@ else:
     ColType = Column
 
 ColumnDefaults = Dict[bool, Any]
-ColumnValues = Dict[ColType, Any]
+ColumnValues = Callable[[ColType], Any]
 ColumnSet = Set[ColType]
 MapperTargets = Dict[Type[Any], Dict[ColType, str]]

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -12,6 +12,11 @@ INT_C = Column("int_c", Integer)
 TEXT = Column("text", Text)
 
 
+def values(mapping):
+    """Returns the getitem operator for the given dictionary."""
+    return mapping.__getitem__
+
+
 # Equality and comparability
 def test_expression_self_equality():
     expr = Expression(BOOL_A & (INT_A > 5))
@@ -53,7 +58,7 @@ def test_serlialize_unsupported_opeator():
 )
 def test_bool_expr_direct_column(inputs, expected):
     expression = Expression(BOOL_A)
-    assert expression.evaluate(inputs) == expected
+    assert expression.evaluate(values(inputs)) == expected
 
 
 @pytest.mark.parametrize(
@@ -61,7 +66,7 @@ def test_bool_expr_direct_column(inputs, expected):
 )
 def test_bool_expr_negation(inputs, expected):
     expression = Expression(~BOOL_A)
-    assert expression.evaluate(inputs) == expected
+    assert expression.evaluate(values(inputs)) == expected
 
 
 @pytest.mark.parametrize(
@@ -75,7 +80,7 @@ def test_bool_expr_negation(inputs, expected):
 )
 def test_bool_expr_conjunction(inputs, expected):
     expression = Expression(BOOL_A & BOOL_B)
-    assert expression.evaluate(inputs) == expected
+    assert expression.evaluate(values(inputs)) == expected
 
 
 @pytest.mark.parametrize(
@@ -89,7 +94,7 @@ def test_bool_expr_conjunction(inputs, expected):
 )
 def test_bool_expr_disjunction(inputs, expected):
     expression = Expression(BOOL_A | BOOL_B)
-    assert expression.evaluate(inputs) == expected
+    assert expression.evaluate(values(inputs)) == expected
 
 
 @pytest.mark.parametrize(
@@ -107,7 +112,7 @@ def test_bool_expr_disjunction(inputs, expected):
 )
 def test_bool_expr_mixed(inputs, expected):
     expression = Expression((BOOL_A & ~BOOL_B) | BOOL_C)
-    assert expression.evaluate(inputs) == expected
+    assert expression.evaluate(values(inputs)) == expected
 
 
 @pytest.mark.parametrize(
@@ -121,7 +126,7 @@ def test_bool_expr_mixed(inputs, expected):
 )
 def test_bool_conjunction_clauselists(inputs, expected):
     expression = Expression(and_(BOOL_A, BOOL_B, BOOL_C))
-    assert expression.evaluate(inputs) == expected
+    assert expression.evaluate(values(inputs)) == expected
 
 
 @pytest.mark.parametrize(
@@ -135,7 +140,7 @@ def test_bool_conjunction_clauselists(inputs, expected):
 )
 def test_bool_disjunction_clauselists(inputs, expected):
     expression = Expression(or_(BOOL_A, BOOL_B, BOOL_C))
-    assert expression.evaluate(inputs) == expected
+    assert expression.evaluate(values(inputs)) == expected
 
 
 @pytest.mark.parametrize(
@@ -149,49 +154,49 @@ def test_bool_disjunction_clauselists(inputs, expected):
 )
 def test_bool_empty_clauselists(clause):
     expression = Expression(clause)
-    assert expression.evaluate({})
+    assert expression.evaluate(values({}))
 
 
 # Math expression evaluation
 def test_addition():
     expr = Expression(INT_A + INT_B)
-    assert expr.evaluate({INT_A: 2, INT_B: -10}) == -8
+    assert expr.evaluate(values({INT_A: 2, INT_B: -10})) == -8
 
 
 def test_subtraction():
     expr = Expression(INT_A - INT_B)
-    assert expr.evaluate({INT_A: 2, INT_B: 5}) == -3
+    assert expr.evaluate(values({INT_A: 2, INT_B: 5})) == -3
 
 
 def test_division():
     expr = Expression(INT_A / INT_B)
-    assert expr.evaluate({INT_A: 4, INT_B: 2}) == 2
+    assert expr.evaluate(values({INT_A: 4, INT_B: 2})) == 2
 
 
 def test_multiplication():
     expr = Expression(INT_A * INT_B)
-    assert expr.evaluate({INT_A: 4, INT_B: -3}) == -12
+    assert expr.evaluate(values({INT_A: 4, INT_B: -3})) == -12
 
 
 def test_bitwise_inversion():
     expr = Expression(~INT_A)
-    assert expr.evaluate({INT_A: 127}) == -128
-    assert expr.evaluate({INT_A: -128}) == 127
+    assert expr.evaluate(values({INT_A: 127})) == -128
+    assert expr.evaluate(values({INT_A: -128})) == 127
 
 
 def test_mixed_math():
     expr = Expression((INT_A * INT_B) + (INT_A / INT_C))
-    assert expr.evaluate({INT_A: 8, INT_B: 2, INT_C: 4}) == 18
+    assert expr.evaluate(values({INT_A: 8, INT_B: 2, INT_C: 4})) == 18
 
 
 # Test additional expression evaluation
 def test_evaluate_bind_param_equals():
     expr = Expression(INT_A == 5)
-    assert not expr.evaluate({INT_A: 4})
-    assert expr.evaluate({INT_A: 5})
+    assert not expr.evaluate(values({INT_A: 4}))
+    assert expr.evaluate(values({INT_A: 5}))
 
 
 def test_evaluate_bind_param_contains():
     expr = Expression(INT_A.in_([1, 2, 3, 4, 5]))
-    assert expr.evaluate({INT_A: 3})
-    assert not expr.evaluate({INT_A: 6})
+    assert expr.evaluate(values({INT_A: 3}))
+    assert not expr.evaluate(values({INT_A: 6}))

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -63,9 +63,9 @@ def make_resolver(Thing, resolver_type):
 def test_resolve_simple_values(Thing, column_map, make_resolver, params):
     thing = Thing(**params)
     resolver = make_resolver(column_map.values())
-    resolved_values = resolver.values(thing)
+    value_resolver = resolver.values(thing)
     for attr_name, column in column_map.items():
-        assert getattr(thing, attr_name) == resolved_values[column]
+        assert getattr(thing, attr_name) == value_resolver(column)
 
 
 def test_single_name_getter(Thing, column_map, make_resolver):
@@ -94,8 +94,8 @@ def test_ambiguous_attribute_names_across_mappers(make_resolver):
     alias = Alias("eggs")
     assert resolver.single_name(base) == "value"
     assert resolver.single_name(alias) == "alias"
-    assert resolver.values(base) == {table.c.value: "spam"}
-    assert resolver.values(alias) == {table.c.value: "eggs"}
+    assert resolver.values(base)(table.c.value) == "spam"
+    assert resolver.values(alias)(table.c.value) == "eggs"
 
 
 @pytest.mark.parametrize("prefetch", [False, True])

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -75,6 +75,13 @@ def test_single_name_getter(Thing, column_map, make_resolver):
         assert resolver.single_name(thing) == attr_name
 
 
+def test_single_name_multi_column(Thing, column_map, make_resolver):
+    thing = Thing()
+    resolver = make_resolver(set(column_map.values()))
+    with pytest.raises(ValueError, match="Resolver contains multiple columns"):
+        resolver.single_name(thing)
+
+
 def test_ambiguous_attribute_names_across_mappers(make_resolver):
     """Ambiguously mapped column works normally for AttributeResolver."""
     table = Table("test", MetaData(), Column("value", Text, primary_key=True))


### PR DESCRIPTION
* Adds support for multi-clause (3+) boolean AND/OR expressions;
* Inlines the `Stack` class to the `Expression.evaluate` method;
* Adds dedicated branches for one and two argument clause functions.
* Replaces the dictionary returned from `Resolver.values` with a lookup function
* Adds errors for accessing `Resolver.single_name` for multi-column cases
* Optimizes the single column access on the `Resolver`.

This reduces the time taken for both getters and setters:

* Getter: single column `is not None` reduced by about 33% (or +50% calls per second)
* Getter: Multi-column expression evaluation is similarly down about -33%
* Setter: about a 10% reduction in time taken compared to before

There's still a difference in performance between a hand-coded `hybrid_property`. Averaging a getter across a True and False result, the hand-coded one takes approximately 0.95 microseconds, whereas the `derived_column` takes closer to 3.7 microseconds. 

Setter amd `expression` performance are still significantly better than on the base `hybrid_property`, with setters being about 3x faster (5us to 1.7us) and the expression over 5x (8us to 1.4us).