### PR TITLE
Symbol and expression parsing improvements

### DIFF
--- a/src/sqlalchemy_hybrid_utils/typing.py
+++ b/src/sqlalchemy_hybrid_utils/typing.py
@@ -1,13 +1,16 @@
-from typing import TYPE_CHECKING, Any, Callable, Dict, Set, Type
+from typing import TYPE_CHECKING, Any, Callable, Dict, Set, Type, Union
 
+from sqlalchemy.sql.elements import ColumnElement
 from sqlalchemy.sql.schema import Column
 
 if TYPE_CHECKING:
-    ColType = Column[Any]
+    ColType = Union[Column[Any], ColumnElement[Any]]
 else:
-    ColType = Column
+    ColType = Union[Column, ColumnElement]
 
 ColumnDefaults = Dict[bool, Any]
 ColumnValues = Callable[[ColType], Any]
 ColumnSet = Set[ColType]
+Function = Callable[..., Any]
+FunctionMap = Dict[Function, Function]
 MapperTargets = Dict[Type[Any], Dict[ColType, str]]

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -200,3 +200,17 @@ def test_evaluate_bind_param_contains():
     expr = Expression(INT_A.in_([1, 2, 3, 4, 5]))
     assert expr.evaluate(values({INT_A: 3}))
     assert not expr.evaluate(values({INT_A: 6}))
+
+
+@pytest.mark.parametrize(
+    "inputs, expected",
+    [
+        ({INT_A: 4, INT_B: 1, INT_C: 1}, False),
+        ({INT_A: 4, INT_B: 2, INT_C: 2}, True),
+        ({INT_A: 4, INT_B: 3, INT_C: 3}, False),
+        ({INT_A: 4, INT_B: 4, INT_C: 4}, True),
+    ],
+)
+def test_evaluate_grouping(inputs, expected):
+    expr = Expression(INT_A.in_([INT_B, INT_C * 2]))
+    assert expr.evaluate(values(inputs)) == expected

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -3,6 +3,7 @@ from sqlalchemy import Boolean, Column
 
 from sqlalchemy_hybrid_utils.expression import (
     ColumnSymbol,
+    GroupingSymbol,
     LiteralSymbol,
     OperatorSymbol,
 )
@@ -37,6 +38,11 @@ def test_symbol_other_type_inequality(other):
 def test_symbol_column_must_be_column():
     with pytest.raises(TypeError, match="Value must be column-like:"):
         ColumnSymbol("foo")  # type: ignore[arg-type]
+
+
+def test_symbol_grouping_arity_must_be_integer():
+    with pytest.raises(TypeError, match="Arity must be an integer:"):
+        GroupingSymbol("1")  # type: ignore[arg-type]
 
 
 def test_symbol_operator_must_be_callable():

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -1,42 +1,49 @@
 import pytest
 from sqlalchemy import Boolean, Column
 
-from sqlalchemy_hybrid_utils.expression import Symbol
+from sqlalchemy_hybrid_utils.expression import (
+    ColumnSymbol,
+    LiteralSymbol,
+    OperatorSymbol,
+)
 
 BOOL_A = Column("bool_a", Boolean)
 BOOL_B = Column("bool_b", Boolean)
 
 
 def test_symbol_equality():
-    left = Symbol(BOOL_A)
-    right = Symbol(BOOL_A)
+    left = ColumnSymbol(BOOL_A)
+    right = ColumnSymbol(BOOL_A)
     assert left is not right
     assert left == right
 
 
-def test_symbol_inequality():
-    left = Symbol(BOOL_A)
-    right = Symbol(BOOL_B)
+@pytest.mark.parametrize(
+    "left, right",
+    [
+        (ColumnSymbol(BOOL_A), ColumnSymbol(BOOL_B)),
+        (ColumnSymbol(BOOL_A), LiteralSymbol(BOOL_A)),
+    ],
+)
+def test_symbol_inequality(left, right):
     assert left != right
 
 
 @pytest.mark.parametrize("other", [[], [None], 0, 100, "bool_a", True, False, None])
 def test_symbol_other_type_inequality(other):
-    assert Symbol(BOOL_A) != other
+    assert ColumnSymbol(BOOL_A) != other
 
 
-@pytest.mark.parametrize("value", [BOOL_A, [1, 2], None, 5])
-def test_symbol_arity_operator_only(value):
-    with pytest.raises(ValueError, match="Arity not allowed"):
-        Symbol(value, arity=2)
+def test_symbol_column_must_be_column():
+    with pytest.raises(TypeError, match="Value must be column-like:"):
+        ColumnSymbol("foo")  # type: ignore[arg-type]
 
 
-def test_symbol_operator_arity_required():
-    with pytest.raises(ValueError, match="Arity required"):
-        Symbol(all)
+def test_symbol_operator_must_be_callable():
+    with pytest.raises(TypeError, match="Operator must be callable:"):
+        OperatorSymbol("foo", arity=1)  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize("value, arity", [(BOOL_A, None), (any, 2), (5, None)])
-def test_symbol_representation(value, arity):
-    symbol = Symbol(value, arity=arity)
-    assert repr(symbol)
+def test_symbol_operator_arity_must_be_integer():
+    with pytest.raises(TypeError, match="Arity must be an integer:"):
+        OperatorSymbol(any, "1")  # type: ignore[arg-type]


### PR DESCRIPTION
Replaces the Symbol class with embedded SymbolType enum with a set of subclassed Symbol classes. This removes costly tuple-unpacking from the for-loop in the `Expression.evaluate` loop which saves a significant amount of overhead (on the order of 30%).

Also adds support for `Grouping` sets more complex than a list of `BindParam` and resolves the type error by means of a (superfluous but illustrative) conditional.

It removes some tests related to the representation of the Symbol, as these are now provided by the dataclass they derive from.